### PR TITLE
ONEMPERS-135 adding LGI addon methods for DisplaySettings plugin

### DIFF
--- a/DisplaySettings/CMakeLists.txt
+++ b/DisplaySettings/CMakeLists.txt
@@ -15,14 +15,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(PLUGIN_NAME DisplaySettings)
+set(PLUGIN_NAME DisplaySettingsLgiAddons)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
 find_package(${NAMESPACE}Plugins REQUIRED)
 
 add_library(${MODULE_NAME} SHARED
         DisplaySettings.cpp
+        DisplaySettingsLgiAddons.cpp
         Module.cpp
+        ServiceRegistration.cpp
 	../helpers/tptimer.cpp
         ../helpers/utils.cpp)
 
@@ -32,13 +34,23 @@ set_target_properties(${MODULE_NAME} PROPERTIES
 
 target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
 
+add_compile_definitions(USE_LGI_DEVICESETTINGS_IMPLEMENTATION)
+
+find_package(CURL)
+if (CURL_FOUND)
+        include_directories(${CURL_INCLUDE_DIRS})
+        target_link_libraries(${MODULE_NAME} PRIVATE ${CURL_LIBRARIES})
+else (CURL_FOUND)
+        message ("Curl/libcurl required.")
+endif (CURL_FOUND)
+
 find_package(DS)
 if (DS_FOUND)
     find_package(IARMBus)
     add_definitions(-DDS_FOUND)
     target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
     target_include_directories(${MODULE_NAME} PRIVATE ${DS_INCLUDE_DIRS})
-    target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES} ${DS_LIBRARIES} "-ltr181api")
+    target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${NAMESPACE}SecurityUtil ${IARMBUS_LIBRARIES} ${DS_LIBRARIES} "-ltr181api")
 else (DS_FOUND)
     target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins)
 endif(DS_FOUND)

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -1356,14 +1356,13 @@ namespace WPEFramework {
                 device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
                 if (vPort.isDisplayConnected())
                 {
-                    int videoEOTF, matrixCoefficients, colorSpace, colorDepth, quantizationRange;
-                    vPort.getCurrentOutputSettings(videoEOTF, matrixCoefficients, colorSpace, colorDepth, quantizationRange);
+                    int videoEOTF, matrixCoefficients, colorSpace, colorDepth;
+                    vPort.getCurrentOutputSettings(videoEOTF, matrixCoefficients, colorSpace, colorDepth);
 
                     response["colorSpace"] = colorSpace;
                     response["colorDepth"] = colorDepth;
                     response["matrixCoefficients"] = matrixCoefficients;
                     response["videoEOTF"] = videoEOTF;
-                    response["quantizationRange"] = quantizationRange;
                 }
                 else
                 {

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -54,7 +54,6 @@ using namespace std;
 
 #define HDMI_IN_ARC_PORT_ID 1
 
-
 #define HDMICECSINK_CALLSIGN "org.rdk.HdmiCecSink"
 #define HDMICECSINK_CALLSIGN_VER HDMICECSINK_CALLSIGN".1"
 #define HDMICECSINK_ARC_INITIATION_EVENT "arcInitiationEvent"
@@ -124,12 +123,10 @@ namespace WPEFramework {
 
     namespace Plugin {
 
-        SERVICE_REGISTRATION(DisplaySettings, 1, 0);
-
         DisplaySettings* DisplaySettings::_instance = nullptr;
 
-        DisplaySettings::DisplaySettings()
-            : AbstractPlugin()
+        DisplaySettings::DisplaySettings(bool hdmiCecSinkAvailable)
+            : AbstractPlugin(), hdmiCecSinkAvailable(hdmiCecSinkAvailable)
         {
             LOGINFO("ctor");
             DisplaySettings::_instance = this;
@@ -196,7 +193,15 @@ namespace WPEFramework {
             registerMethod("getDefaultResolution", &DisplaySettings::getDefaultResolution, this);
             registerMethod("setScartParameter", &DisplaySettings::setScartParameter, this);
 
-	    m_timer.connect(std::bind(&DisplaySettings::onTimer, this));
+            if (!hdmiCecSinkAvailable)
+            {
+                LOGWARN("HdmiCecSink is not available; HDMI_ARC events will not be set up");
+                LOGWARN("do not expect ARC to fully work !");
+            }
+            else
+            {
+                m_timer.connect(std::bind(&DisplaySettings::onTimer, this));
+            }
         }
 
         DisplaySettings::~DisplaySettings()
@@ -277,9 +282,12 @@ namespace WPEFramework {
                 m_timer.stop();
             }
 
-            Utils::activatePlugin(HDMICECSINK_CALLSIGN);
-            LOGINFO("Starting the timer");
-            m_timer.start(RECONNECTION_TIME_IN_MILLISECONDS);
+            if (hdmiCecSinkAvailable)
+            {
+                Utils::activatePlugin(HDMICECSINK_CALLSIGN);
+                LOGINFO("Starting the timer");
+                m_timer.start(RECONNECTION_TIME_IN_MILLISECONDS);
+            }
 
             InitAudioPorts();
 
@@ -1047,6 +1055,8 @@ namespace WPEFramework {
             }
             else if (soundMode == "dolby digital 5.1")
                 mode = device::AudioStereoMode::kSurround;
+            else if (soundMode == "follow")
+                mode = device::AudioStereoMode::kFollow;
             else
             {
                 LOGWARN("Sound mode '%s' is empty or incompatible with known values, hence sound mode will not changed!", soundMode.c_str());
@@ -1197,7 +1207,7 @@ namespace WPEFramework {
             LOGINFOMETHOD();
 
             string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : "HDMI0";
-            bool active = true;
+            bool active = false;
             try
             {
                 device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort(videoDisplay);
@@ -2603,6 +2613,15 @@ namespace WPEFramework {
         void DisplaySettings::onTimer()
         {
             LOGINFO();
+            if (!hdmiCecSinkAvailable)
+            {
+                LOGERR("HdmiCecSink not available; HDMI_ARC events will not be set up");
+                if (m_timer.isActive())
+                {
+                    m_timer.stop();
+                }
+                return;
+            }
 	    m_callMutex.lock();
             static bool isInitDone = false;
             bool pluginActivated = Utils::isPluginActivated(HDMICECSINK_CALLSIGN);

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -128,7 +128,7 @@ namespace WPEFramework {
             void onARCTerminationEventHandler(const JsonObject& parameters);
             //End events
         public:
-            DisplaySettings();
+            DisplaySettings(bool hdmiCecSinkAvailable = true);
             virtual ~DisplaySettings();
             //IPlugin methods
             virtual const string Initialize(PluginHost::IShell* service) override;
@@ -155,9 +155,13 @@ namespace WPEFramework {
 	    JsonObject m_audioOutputPortConfig;
             JsonObject getAudioOutputPortConfig() { return m_audioOutputPortConfig; }
 
+        const bool hdmiCecSinkAvailable;
+
         public:
             static DisplaySettings* _instance;
 
         };
+
+        void setResponseArray(JsonObject& response, const char* key, const std::vector<std::string>& items);
 	} // namespace Plugin
 } // namespace WPEFramework

--- a/DisplaySettings/DisplaySettingsLgiAddons.config
+++ b/DisplaySettings/DisplaySettingsLgiAddons.config
@@ -1,0 +1,12 @@
+set (autostart ${PLUGIN_DISPLAYSETTINGS_AUTOSTART})
+set (preconditions Platform)
+set (callsign "org.rdk.DisplaySettings")
+map()
+    key(root)
+    map()
+      kv(outofprocess ${PLUGIN_DISPLAYSETTINGS_OUTOFPROCESS})
+    end()
+end()
+
+ans(configuration)
+

--- a/DisplaySettings/DisplaySettingsLgiAddons.cpp
+++ b/DisplaySettings/DisplaySettingsLgiAddons.cpp
@@ -1,0 +1,322 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2021 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#include "DisplaySettingsLgiAddons.h"
+#include <algorithm>
+
+#include "host.hpp"
+#include "exception.hpp"
+#include "videoOutputPort.hpp"
+#include "videoOutputPortType.hpp"
+#include "videoOutputPortConfig.hpp"
+#include "videoResolution.hpp"
+#include "audioOutputPort.hpp"
+#include "audioOutputPortType.hpp"
+#include "audioOutputPortConfig.hpp"
+#include "dsError.h"
+
+using namespace std;
+
+namespace WPEFramework {
+
+    namespace Plugin {
+
+        static bool parseQBool(const std::string& str)
+        {
+            // https://doc.qt.io/qt-5/qvariant.html#toBool:
+            // 'Returns true if (...) lower-case content is not one of the following: empty, "0" or "false"; otherwise returns false.'
+            string lowercase_string;
+            std::transform(str.begin(),
+                           str.end(),
+                           lowercase_string.begin(),
+                           ::tolower);
+            return !(lowercase_string.empty() || lowercase_string == "false" || lowercase_string == "0");
+        }
+
+        DisplaySettingsLgiAddons::DisplaySettingsLgiAddons() : DisplaySettings(false)
+        {
+            registerMethod("setOutputFrameRatePreference", &DisplaySettingsLgiAddons::setOutputFrameRatePreference, this);
+            registerMethod("setAudioProcessingHint", &DisplaySettingsLgiAddons::setAudioProcessingHint, this);
+            registerMethod("getAudioOutputEncoding", &DisplaySettingsLgiAddons::getAudioOutputEncoding, this);
+            registerMethod("getFollowColorSpace", &DisplaySettingsLgiAddons::getFollowColorSpace, this);
+            registerMethod("setFollowColorSpace", &DisplaySettingsLgiAddons::setFollowColorSpace, this);
+            registerMethod("getPreferredOutputColorSpace", &DisplaySettingsLgiAddons::getPreferredOutputColorSpace, this);
+            registerMethod("setPreferredOutputColorSpace", &DisplaySettingsLgiAddons::setPreferredOutputColorSpace, this);
+            registerMethod("getHDRGfxColorSpace", &DisplaySettingsLgiAddons::getHDRGfxColorSpace, this);
+            registerMethod("setHDRGfxColorSpace", &DisplaySettingsLgiAddons::setHDRGfxColorSpace, this);
+        }
+
+        uint32_t DisplaySettingsLgiAddons::setOutputFrameRatePreference(const JsonObject& parameters, JsonObject& response)
+        {
+            // servicemanager params: (const bool followContent);
+            LOGINFOMETHOD();
+            bool success = false;
+            returnIfParamNotFound(parameters, "followContent");
+            const string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : "HDMI0";
+            const bool followContent = parseQBool(parameters["followContent"].String());
+
+            try
+            {
+                device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort(videoDisplay);
+                vPort.setOutputFrameRatePreference(followContent);
+                success = true;
+            }
+            catch (const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION0();
+            }
+
+            returnResponse(success);
+        }
+
+        uint32_t DisplaySettingsLgiAddons::setAudioProcessingHint(const JsonObject& parameters, JsonObject& response)
+        {
+            // servicemanager params: (QString audioPort, QString audioMode, QString audioDelayMs);
+            LOGINFOMETHOD();
+            bool success = false;
+            returnIfParamNotFound(parameters, "audioMode");
+            const string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+            // TODO: checkPortName?
+
+            int64_t _delayMs = -1;
+            getDefaultNumberParameter("audioDelayMs", _delayMs, -1);
+            if (_delayMs >= 0 && _delayMs <= std::numeric_limits<uint32_t>::max())
+            {
+                const string audioMode = parameters["audioMode"].String();
+                const uint32_t delayMs = _delayMs;
+                try
+                {
+                    device::AudioOutputPort &aPort = device::AudioOutputPortConfig::getInstance().getPort(audioPort);
+                    aPort.setAudioDelayHint(delayMs, audioMode);
+                    success = true;
+                }
+                catch(const device::Exception& err)
+                {
+                    LOG_DEVICE_EXCEPTION0();
+                }
+            }
+            else
+            {
+                LOGWARN("setAudioProcessingHint: audioDelayMs value %lld out of uint32_t bounds; not executed", _delayMs);
+            }
+
+            returnResponse(success);
+        }
+
+        uint32_t DisplaySettingsLgiAddons::getAudioOutputEncoding(const JsonObject& parameters, JsonObject& response)
+        {
+            // servicemanager params: (QString audioPort);
+            LOGINFOMETHOD();
+            bool success = false;
+
+            const string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+            // TODO: checkPortName?
+
+            try
+            {
+                device::AudioOutputPort &aPort = device::AudioOutputPortConfig::getInstance().getPort(audioPort);
+                const device::AudioEncoding &aEnc = aPort.getEncoding();
+                response["encoding"] = aEnc.getName();
+                success = true;
+            }
+            catch(const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION0();
+            }
+
+            returnResponse(success);
+        }
+
+        uint32_t DisplaySettingsLgiAddons::getFollowColorSpace(const JsonObject& parameters, JsonObject& response)
+        {
+            // servicemanager params: (QString videoDisplay) const;
+            LOGINFOMETHOD();
+            bool success = false;
+            const string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : "HDMI0";
+
+            try
+            {
+                device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort(videoDisplay);
+                response["followColorSpace"] = vPort.getFollowColorSpace();
+                success = true;
+            }
+            catch(const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION0();
+            }
+
+            returnResponse(success);
+        }
+
+        uint32_t DisplaySettingsLgiAddons::setFollowColorSpace(const JsonObject& parameters, JsonObject& response)
+        {
+            // servicemanager params: (QString videoDisplay, bool followCOlorSpace);
+            LOGINFOMETHOD();
+            bool success = false;
+            const string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : "HDMI0";
+            returnIfParamNotFound(parameters, "followColorSpace");
+
+            const bool followColorSpace = parseQBool(parameters["followColorSpace"].String());
+
+            try
+            {
+                device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort(videoDisplay);
+                vPort.setFollowColorSpace(followColorSpace);
+                success = true;
+            }
+            catch(const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION0();
+            }
+
+            returnResponse(success);
+        }
+
+        uint32_t DisplaySettingsLgiAddons::getPreferredOutputColorSpace(const JsonObject& parameters, JsonObject& response)
+        {
+            // servicemanager params: (const QString videoDisplay);
+            LOGINFOMETHOD();
+            bool success = false;
+            const string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : "HDMI0";
+
+            try
+            {
+                std::string result;
+                device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort(videoDisplay);
+                if (vPort.getPreferredOutputColorSpace(result))
+                {
+                    // the result is comma-separated list of values, like 'BT2020_NCL,BT2020_CL,BT709'
+                    string colorSpace;
+                    stringstream ss {result};
+                    vector<string> colorSpaces;
+                    while (getline(ss, colorSpace, ',')) {
+                        colorSpaces.push_back(colorSpace);
+                    }
+                    setResponseArray(response, "preferredOutputColorSpaces", colorSpaces);
+                    success = true;
+                }
+            }
+            catch (const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION0();
+            }
+
+            returnResponse(success);
+        }
+
+        uint32_t DisplaySettingsLgiAddons::setPreferredOutputColorSpace(const JsonObject& parameters, JsonObject& response)
+        {
+            // servicemanager params: (const QString videoDisplay, const QString colorSpaces);
+            // here, we expect colorSpaces to be array
+            LOGINFOMETHOD();
+            bool success = false;
+            const string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : "HDMI0";
+
+            returnIfParamNotFound(parameters, "colorSpaces");
+            auto colorSpacesArr = parameters["colorSpaces"].Array();
+            auto colorSpaces = colorSpacesArr.Elements();
+
+            try
+            {
+                stringstream strColorSpaces;
+                bool first = true;
+                while (colorSpaces.Next())
+                {
+                    if (!first) strColorSpaces << ",";
+                    first = false;
+                    strColorSpaces << colorSpaces.Current().String();
+                }
+                device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort(videoDisplay);
+                success = vPort.setPreferredOutputColorSpace(strColorSpaces.str());
+            }
+            catch (const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION0();
+            }
+
+            returnResponse(success);
+        }
+
+        uint32_t DisplaySettingsLgiAddons::getHDRGfxColorSpace(const JsonObject& parameters, JsonObject& response)
+        {
+            // servicemanager params: (QString videoPort, int &y, int &cr, int &cb);
+            LOGINFOMETHOD();
+            bool success = false;
+            const string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : "HDMI0";
+
+            try {
+                int16_t y, cr, cb;
+                device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(videoDisplay);
+
+                vPort.getType().getInstance(device::VideoOutputPortType::kHDMI).GetHDRGfxColorSpace(&y, &cr, &cb);
+                response["y"] = y;
+                response["cr"] = cr;
+                response["cb"] = cb;
+                success = true;
+            }
+            catch(const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION0();
+            }
+
+            returnResponse(success);
+        }
+
+        uint32_t DisplaySettingsLgiAddons::setHDRGfxColorSpace(const JsonObject& parameters, JsonObject& response)
+        {
+            // servicemanager params: (QString videoPort, int y, int cr, int cb);
+            LOGINFOMETHOD();
+            bool success = false;
+            const string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : "HDMI0";
+
+            returnIfParamNotFound(parameters, "y");
+            returnIfParamNotFound(parameters, "cr");
+            returnIfParamNotFound(parameters, "cb");
+
+            int64_t y, cr, cb;
+            getDefaultNumberParameter("y", y, std::numeric_limits<int64_t>::max());
+            getDefaultNumberParameter("cr", cr, std::numeric_limits<int64_t>::max());
+            getDefaultNumberParameter("cb", cb, std::numeric_limits<int64_t>::max());
+
+            if (y < std::numeric_limits<int16_t>::min() || y > std::numeric_limits<int16_t>::max()
+                || cr < std::numeric_limits<int16_t>::min() || cr > std::numeric_limits<int16_t>::max()
+                || cb < std::numeric_limits<int16_t>::min() || cb > std::numeric_limits<int16_t>::max())
+            {
+                LOGWARN("setHDRGfxColorSpace: some of values: y=%lld cr=%lld cb=%lld out of int16_t bounds; not executed", y,cr,cb);
+            }
+            else
+            {
+                int16_t _y = y, _cr = cr, _cb = cb;
+                try
+                {
+                    device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(videoDisplay);
+                    vPort.getType().getInstance(device::VideoOutputPortType::kHDMI).SetHDRGfxColorSpace(&_y, &_cr, &_cb);
+                    success = true;
+                }
+                catch(const device::Exception& err)
+                {
+                    LOG_DEVICE_EXCEPTION0();
+                }
+            }
+
+            returnResponse(success);
+        }
+
+    } // namespace Plugin
+} // namespace WPEFramework

--- a/DisplaySettings/DisplaySettingsLgiAddons.h
+++ b/DisplaySettings/DisplaySettingsLgiAddons.h
@@ -1,0 +1,22 @@
+#include "DisplaySettings.h"
+#include "utils.h"
+
+namespace WPEFramework {
+    namespace Plugin {
+        // all LGI extensions are implemented here
+        class DisplaySettingsLgiAddons : public DisplaySettings
+        {
+            public:
+                DisplaySettingsLgiAddons();
+                uint32_t setOutputFrameRatePreference(const JsonObject& parameters, JsonObject& response); // args: (videoDisplay, followContent)
+                uint32_t setAudioProcessingHint(const JsonObject& parameters, JsonObject& response); // args:  (audioPort, audioMode, audioDelayMs)
+                uint32_t getAudioOutputEncoding(const JsonObject& parameters, JsonObject& response); //args: (audioPort)
+                uint32_t getFollowColorSpace(const JsonObject& parameters, JsonObject& response); // args: (videoDisplay)
+                uint32_t setFollowColorSpace(const JsonObject& parameters, JsonObject& response); // args: (videoDisplay,followColorSpace)
+                uint32_t getPreferredOutputColorSpace(const JsonObject& parameters, JsonObject& response); // args: (videoDisplay)
+                uint32_t setPreferredOutputColorSpace(const JsonObject& parameters, JsonObject& response); // args: (videoDisplay,colorSpaces: array of colorspace string)
+                uint32_t getHDRGfxColorSpace(const JsonObject& parameters, JsonObject& response); // args: (videoDisplay)
+                uint32_t setHDRGfxColorSpace(const JsonObject& parameters, JsonObject& response); // args: (videoDisplay,y,cr,cb)
+        };
+    } //Plugin
+} //WPEFramework

--- a/DisplaySettings/ServiceRegistration.cpp
+++ b/DisplaySettings/ServiceRegistration.cpp
@@ -1,0 +1,14 @@
+#include "core/Services.h"
+#include "DisplaySettings.h"
+#include "DisplaySettingsLgiAddons.h"
+
+namespace WPEFramework {
+    namespace Plugin {
+
+#ifdef USE_LGI_DEVICESETTINGS_IMPLEMENTATION
+        SERVICE_REGISTRATION(DisplaySettingsLgiAddons, 1, 0);
+#else
+        SERVICE_REGISTRATION(DisplaySettings, 1, 0);
+#endif
+
+}}


### PR DESCRIPTION
It is possible to choose between base plugin implementation (without Lgi addons) and Lgi implementation on cmake level (USE_LGI_DEVICESETTINGS_IMPLEMENTATION define)

additionally, cherry-picking 88d64bd - without this revert, the plugin does not compile on lgi branch 