### PR TITLE
DELIA-50319: wpeframework service crash

### DIFF
--- a/FireboltMediaPlayer/FireboltMediaPlayer.cpp
+++ b/FireboltMediaPlayer/FireboltMediaPlayer.cpp
@@ -25,6 +25,52 @@ namespace WPEFramework {
 
     namespace Plugin {
 
+        /**
+         * \brief Destructor ensure all references are released.
+         *
+         */
+        FireboltMediaPlayer::MediaStreamProxy::~MediaStreamProxy()
+        {
+            LOGINFO();
+            if (_implementation) {
+                _implementation->Unregister(&_mediaPlayerSink);
+            }
+            while(_implementation) {
+                auto result = _implementation->Release();
+
+                // If the release wasn't successful then we should stop calling it
+                if (result != Core::ERROR_NONE) {
+                    // Expecting to get destruction succeeded eventually but might encounter an error, e.g out-of-process has been killed
+                    if (result != Core::ERROR_DESTRUCTION_SUCCEEDED)
+                        LOGERR("_implementation->Release() returned %d", result);
+                    _implementation = nullptr;
+                }
+            }
+        }
+
+        /**
+         * \brief Release this instance, destroying if necessary.
+         *
+         * \return Whether the underlying instance could be released.
+         *
+         */
+        uint32_t FireboltMediaPlayer::MediaStreamProxy::Release()
+        {
+            LOGINFO();
+            _implementation->Unregister(&_mediaPlayerSink);
+            auto result = _implementation->Release();
+
+            // If the release wasn't successful then this instance should be destroyed
+            if (result != Core::ERROR_NONE) {
+                // Expecting to get destruction succeeded eventually but might encounter an error, e.g out-of-process has been killed
+                if (result != Core::ERROR_DESTRUCTION_SUCCEEDED)
+                    LOGERR("_implementation->Release() unexpectedly returned %d", result);
+                _implementation = nullptr;
+                delete this;
+            }
+            return result;
+        }
+
         SERVICE_REGISTRATION(FireboltMediaPlayer, 1, 0);
 
         FireboltMediaPlayer::FireboltMediaPlayer()
@@ -81,7 +127,8 @@ namespace WPEFramework {
 
             service->Unregister(&_notification);
 
-            if (_aampMediaPlayer->Release() != Core::ERROR_DESTRUCTION_SUCCEEDED) {
+            auto const result = _aampMediaPlayer->Release();
+            if (result == Core::ERROR_NONE) {
 
                 ASSERT(_aampMediaPlayerConnectionId != 0);
 
@@ -97,6 +144,8 @@ namespace WPEFramework {
                     connection->Release();
                 }
             }
+            else if (result != Core::ERROR_DESTRUCTION_SUCCEEDED) 
+                LOGERR("_aampMediaPlayer->Release() unexpectedly returned %d", result);
 
             _aampMediaPlayer = nullptr;
             _service = nullptr;

--- a/FireboltMediaPlayer/FireboltMediaPlayer.h
+++ b/FireboltMediaPlayer/FireboltMediaPlayer.h
@@ -78,10 +78,10 @@ namespace WPEFramework {
 
                 public:
                     MediaStreamSink(MediaStreamProxy* parent)
-                : _parent(*parent)
-                {
-                        ASSERT(parent != nullptr);
-                }
+                    : _parent(*parent)
+                    {
+                            ASSERT(parent != nullptr);
+                    }
 
                     ~MediaStreamSink() override
                     {
@@ -115,16 +115,7 @@ namespace WPEFramework {
                    _implementation->Register(&_mediaPlayerSink);
                 }
 
-                ~MediaStreamProxy()
-                {
-                    while(_implementation)
-                    {
-                        if(_implementation->Release() == Core::ERROR_DESTRUCTION_SUCCEEDED)
-                        {
-                            _implementation = nullptr;
-                        }
-                    }
-                }
+                virtual ~MediaStreamProxy();
 
                 Exchange::IMediaPlayer::IMediaStream* Stream() {
                     return (_implementation);
@@ -137,16 +128,7 @@ namespace WPEFramework {
                 {
                     _implementation->AddRef();
                 }
-                uint32_t Release()
-                {
-                    if(_implementation->Release() == Core::ERROR_DESTRUCTION_SUCCEEDED)
-                    {
-                        _implementation = nullptr;
-                        delete this;
-                        return Core::ERROR_DESTRUCTION_SUCCEEDED;
-                    }
-                    return Core::ERROR_NONE;
-                }
+                uint32_t Release();
 
                 void OnEvent(const string &eventName, const string &parametersJson)
                 {


### PR DESCRIPTION
The in-process portion of the FireboltMediaPlayer cannot handle the
out-of-process portion stopped unexpectedly; either killed or crashing.
This is because it is assuming the error codes that are returned rather
than handing unexpected ones, such as ERROR_CONNECTION_CLOSED.

Reason for change: explicitly killing the FireboltMediaPlayer
out-of-process micro-service or having it crashes cause wpeframwork
to crash.
Risks: Low
Test Procedure: Launch FireboltMediaPlayer and use kill -9 on its
process.

Signed-off-by: Mikolaj Staworzynski <mikolaj.staworzynski@redembedded.com>

Original source of patch:
https://github.com/rdkcentral/rdkservices/pull/1336/commits/7e4bf2627dceb522818f63478b04e4dccfba8338

Removed one block of patch that we already have:

- Unregister(_T("setPosition"));
+ Unregister(_T("seekTo"));

Additional unregister for _mediaPlayerSink