### PR TITLE
ONEMPERS-135 fix DisplaySetting plugin after rdk devicesettings updates

### DIFF
--- a/helpers/tptimer.h
+++ b/helpers/tptimer.h
@@ -20,8 +20,8 @@
 #ifndef TTIMER_H
 #define TTIMER_H
 
-//#include <core/Timer.h>
-#include <plugins/plugins.h>
+#include <core/Timer.h>
+// #include <plugins/plugins.h>
 
 namespace WPEFramework
 {


### PR DESCRIPTION
devicesettings-hal-headers changed; some enums have been converted to structs -  upstream commit c06251c2ad5f2cc6fe9148e1026d1db4c953b1d4 had to be partially backported to fix that.
Also, tptimer.cpp was breaking because of unnecessary plugins/plugins.h include (probably started happening after Thunder update)