### PR TITLE
COMCAST: set OCDM sharepath to /tmp/OCDM

### DIFF
--- a/OpenCDMi/OCDM.config
+++ b/OpenCDMi/OCDM.config
@@ -21,6 +21,7 @@ end()
 ans(rootobject)
 
 map()
+   kv(sharepath "/tmp/OCDM")
    kv(systems ___array___)
 end()
 ans(configuration)


### PR DESCRIPTION
Signed-off-by: Gurdal Oruklu <gurdal_oruklu@comcast.com>