### PR TITLE
[ONEM-20727] Replace persistentPath with diskCacheDir

### DIFF
--- a/WebKitBrowser/WebKitBrowser.cpp
+++ b/WebKitBrowser/WebKitBrowser.cpp
@@ -38,7 +38,18 @@ namespace Plugin {
         _service = service;
         _skipURL = _service->WebPrefix().length();
 
+        // If DiskCacheDir value exist in plugins/WebKitBrowser.json DiskCacheDir
+        // it should replace the original persistentStoragePath with its path data
         _persistentStoragePath = _service->PersistentPath();
+        std::string configLine = _service->ConfigLine();
+        if (!configLine.empty()) {
+            JsonObject serviceConfig = JsonObject(configLine.c_str());
+            if (serviceConfig.HasLabel("diskcachedir")) {
+                _persistentStoragePath = serviceConfig["diskcachedir"].String();
+            } else {
+                TRACE(Trace::Error, (string(_T("Failed to overwrite persistentPath"))));
+            }
+        }
 
         // Register the Connection::Notification stuff. The Remote process might die before we get a
         // change to "register" the sink for these events !!! So do it ahead of instantiation.

--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -1607,7 +1607,9 @@ static GSourceFuncs _handlerIntervention =
             }
 
             Core::SystemInfo::SetEnvironment(_T("QUEUEPLAYER_FLUSH_MODE"), _T("3"), false);
-            Core::SystemInfo::SetEnvironment(_T("HOME"), service->PersistentPath());
+            // Change HOME environment value from config.json PersistentPath to plugins/WebKitBrowser.json DiskCacheDir
+            Core::SystemInfo::SetEnvironment(_T("HOME"),
+                _config.DiskCacheDir.Value().empty() ? _service->PersistentPath() : _config.DiskCacheDir.Value());
 
             if (_config.ClientIdentifier.IsSet() == true) {
                 string value(service->Callsign() + ',' + _config.ClientIdentifier.Value());
@@ -1634,8 +1636,11 @@ static GSourceFuncs _handlerIntervention =
             // GStreamer on-disk buffering
             if (_config.MediaDiskCache.Value() == false)
                 Core::SystemInfo::SetEnvironment(_T("WPE_SHELL_DISABLE_MEDIA_DISK_CACHE"), _T("1"), !environmentOverride);
-            else
-                Core::SystemInfo::SetEnvironment(_T("WPE_SHELL_MEDIA_DISK_CACHE_PATH"), service->PersistentPath(), !environmentOverride);
+            else {
+                // Change WPE_SHELL_MEDIA_DISK_CACHE_PATH environment value from config.json PersistentPath to plugins/WebKitBrowser.json DiskCacheDir
+                Core::SystemInfo::SetEnvironment(_T("WPE_SHELL_MEDIA_DISK_CACHE_PATH"),
+                    _config.DiskCacheDir.Value().empty() ? _service->PersistentPath() : _config.DiskCacheDir.Value(),  !environmentOverride);
+            }
 
             // Disk Cache
             if (_config.DiskCache.Value().empty() == false)


### PR DESCRIPTION
WebKitBrowser is launched via WPEProcess which takes as
argument -p persistentPath which doesn't exists.
Instead of using persistentPath to setup HOME or
WPE_SHELL_MEDIA_DISK_CACHE_PATH, use configuration
file plugins/WebKitBrowser.json DiskCacheDir.