### PR TITLE
Revert "COMCAST: set OCDM sharepath to /tmp/OCDM"

### DIFF
--- a/OpenCDMi/OCDM.config
+++ b/OpenCDMi/OCDM.config
@@ -26,7 +26,6 @@ end()
 ans(rootobject)
 
 map()
-   kv(sharepath "/tmp/OCDM")
    kv(systems ___array___)
    if (NOT PLUGIN_OPENCDMI_MODE)
        kv(outofprocess ${PLUGIN_OPENCDMI_OOP})


### PR DESCRIPTION
This reverts commit 5cd8103307128316901713f4bb348fe021ffa4d1.