### PR TITLE
[ONEM-22983] drm initialization events for COMRPC and JSONRPC

### DIFF
--- a/OpenCDMi/CMakeLists.txt
+++ b/OpenCDMi/CMakeLists.txt
@@ -21,6 +21,7 @@ set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 find_package(ocdm REQUIRED)
 find_package(${NAMESPACE}Plugins REQUIRED)
 find_package(CompileSettingsDebug CONFIG REQUIRED)
+find_package(${NAMESPACE}Definitions REQUIRED)
 
 add_library(${MODULE_NAME} SHARED 
         OCDM.cpp
@@ -37,10 +38,12 @@ set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES)
 
+target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
 target_link_libraries(${MODULE_NAME} 
         PRIVATE
                 CompileSettingsDebug::CompileSettingsDebug
                 ${NAMESPACE}Plugins::${NAMESPACE}Plugins 
+                ${NAMESPACE}Definitions::${NAMESPACE}Definitions
                 ocdm::ocdm)
 # Library definition section
 install(TARGETS ${MODULE_NAME} 

--- a/OpenCDMi/OCDM.cpp
+++ b/OpenCDMi/OCDM.cpp
@@ -120,7 +120,7 @@ namespace Plugin {
 
                 _memory = WPEFramework::OCDM::MemoryObserver(connection);
                 ASSERT(_memory != nullptr);
-
+                _opencdmi->Register(&_notification);
                 connection->Release();
             }
             else {
@@ -142,7 +142,7 @@ namespace Plugin {
 
         _service->Unregister(&_notification);
         _memory->Release();
-
+        _opencdmi->Unregister(&_notification);
         _opencdmi->Deinitialize(service);
         RPC::IRemoteConnection* connection(_service->RemoteConnection(_connectionId));
         uint32_t result = _opencdmi->Release();

--- a/OpenCDMi/OCDMJsonRpc.cpp
+++ b/OpenCDMi/OCDMJsonRpc.cpp
@@ -34,7 +34,7 @@ namespace Plugin {
     {
         Property<Core::JSON::ArrayType<DrmData>>(_T("drms"), &OCDM::get_drms, nullptr, this);
         Property<Core::JSON::ArrayType<Core::JSON::String>>(_T("keysystems"), &OCDM::get_keysystems, nullptr, this);
-        Property<Core::JSON::ArrayType<SessionData>>(_T("sessions"), &OCDM::get_sessions, nullptr, this);
+        Property<Core::JSON::ArrayType<SessionInfo>>(_T("sessions"), &OCDM::get_sessions, nullptr, this);
     }
 
     void OCDM::UnregisterAll()
@@ -103,7 +103,7 @@ namespace Plugin {
         return result;
     }
 
-    uint32_t OCDM::get_sessions(Core::JSON::ArrayType<SessionData>& response) const
+    uint32_t OCDM::get_sessions(Core::JSON::ArrayType<SessionInfo>& response) const
     {
         RPC::IStringIterator* drmsIter(_opencdmi->Systems());
         if (drmsIter != nullptr) {
@@ -113,7 +113,7 @@ namespace Plugin {
                 string sessionItem;
                 if (sessionsIter != nullptr) {
                     while (sessionsIter->Next(sessionItem)) {
-                        SessionData session;
+                        SessionInfo session;
                         session.Drm = system;
                         response.Add(session);
                     }


### PR DESCRIPTION
[ONEM-22983] drm initialization events for COMRPC and JSONRPC
[ONEM-22984] Event generation and re-trying implementation

The whole is builded correctly here: https://gerrit.onemw.net/c/meta-lgi-om-common/+/87824 (includes API changes)
Example verification build: https://jenkins.onemw.net/job/EngineeringBuild/7898/

possible to receive after registration to:
{"jsonrpc": "2.0","id": 2, "method": "OCDM.1.register","params": { "event": "drmalreadyinitialized", "id" : "OCDM" }}
event:
{"jsonrpc":"2.0","method":"OCDM.drmalreadyinitialized","params":{"drm":"PlayReady"}}

and after registration to:
{"jsonrpc": "2.0","id": 2, "method": "OCDM.1.register","params": { "event": "drminitializationstatus", "id" : "OCDM" }}

events:
PlayReady BUSY (used by another process)"
{"jsonrpc":"2.0","method":"OCDM.drminitializationstatus","params":{"status":"BUSY","drm":"PlayReady"}}

PlayReady initialized after BUSY and re-trying (SUCCESS):
{"jsonrpc":"2.0","method":"OCDM.drminitializationstatus","params":{"status":"SUCCESS","drm":"PlayReady"}}

PlayReady not initialized after BUSY and re-trying (FAILED):
{"jsonrpc":"2.0","method":"OCDM.drminitializationstatus","params":{"status":"FAILED","drm":"PlayReady"}}

