### PR TITLE
Add com.lgi.rdk.HdmiCec WPE Framework plugin 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,10 @@ if(PLUGIN_HDMICECSINK)
     add_subdirectory(HdmiCecSink)
 endif()
 
+if(PLUGIN_LGIHDMICEC)
+    add_subdirectory(LgiHdmiCec)
+endif()
+
 if(PLUGIN_LOCATIONSYNC)
     add_subdirectory(LocationSync)
 endif()

--- a/HdmiCec/HdmiCec.cpp
+++ b/HdmiCec/HdmiCec.cpp
@@ -107,6 +107,7 @@ namespace WPEFramework
 
         void HdmiCec::Deinitialize(PluginHost::IShell* /* service */)
         {
+            CECDisable();
             HdmiCec::_instance = nullptr;
 
             DeinitializeIARM();

--- a/LgiHdmiCec/CMakeLists.txt
+++ b/LgiHdmiCec/CMakeLists.txt
@@ -1,0 +1,47 @@
+# If not stated otherwise in this file or this component's license file the
+# following copyright and licenses apply:
+#
+# Copyright 2020 RDK Management
+# Copyright 2021 Liberty Global Service B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(PLUGIN_NAME LgiHdmiCec)
+set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
+
+find_package(${NAMESPACE}Plugins REQUIRED)
+
+add_library(${MODULE_NAME} SHARED
+	LgiHdmiCec.cpp
+        Module.cpp
+        ../helpers/utils.cpp)
+
+set_target_properties(${MODULE_NAME} PROPERTIES
+        CXX_STANDARD 11
+        CXX_STANDARD_REQUIRED YES)
+
+find_package(DS)
+find_package(IARMBus)
+find_package(CEC)
+
+target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS} ../helpers)
+target_include_directories(${MODULE_NAME} PRIVATE ${CEC_INCLUDE_DIRS})
+target_include_directories(${MODULE_NAME} PRIVATE ${DS_INCLUDE_DIRS})
+
+target_link_libraries(${MODULE_NAME} PUBLIC ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES} ${CEC_LIBRARIES} ${DS_LIBRARIES} ${NAMESPACE}SecurityUtil)
+
+
+install(TARGETS ${MODULE_NAME}
+        DESTINATION lib/${STORAGE_DIRECTORY}/plugins)
+
+write_config(${PLUGIN_NAME})

--- a/LgiHdmiCec/LgiHdmiCec.config
+++ b/LgiHdmiCec/LgiHdmiCec.config
@@ -1,0 +1,3 @@
+set (autostart false)
+set (preconditions Platform)
+set (callsign "com.lgi.rdk.HdmiCec")

--- a/LgiHdmiCec/LgiHdmiCec.cpp
+++ b/LgiHdmiCec/LgiHdmiCec.cpp
@@ -1,0 +1,1210 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2019 RDK Management
+* Copyright 2021 Liberty Global Service B.V.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#include <cassert>
+#include <mutex>
+
+#include "LgiHdmiCec.h"
+
+
+#include "ccec/Connection.hpp"
+#include "ccec/CECFrame.hpp"
+#include "host.hpp"
+#include "ccec/host/RDK.hpp"
+
+#include "ccec/drivers/iarmbus/CecIARMBusMgr.h"
+
+
+#include "dsMgr.h"
+#include "dsDisplay.h"
+#include "videoOutputPort.hpp"
+#include "manager.hpp"
+
+#include "websocket/URL.h"
+
+#include "utils.h"
+
+#define HDMICEC_METHOD_SET_ENABLED "setEnabled"
+#define HDMICEC_METHOD_GET_ENABLED "getEnabled"
+#define HDMICEC_METHOD_GET_CEC_ADDRESSES "getCECAddresses"
+#define HDMICEC_METHOD_SEND_MESSAGE "sendMessage"
+#define HDMICEC_METHOD_ENABLE_ONE_TOUCH_VIEW "enableOneTouchView"
+#define HDMICEC_METHOD_TRIGGER_ACTION "triggerAction"
+#define HDMICEC_METHOD_SET_PING_INTERVAL "setPingInterval"
+#define HDMICEC_METHOD_GET_CONNECTED_DEVICES "getConnectedDevices"
+#define HDMICEC_METHOD_SET_NAME "setName"
+#define HDMICEC_METHOD_SET_ONE_TOUCH_VIEW_POLICY "setOneTouchViewPolicy"
+
+#define HDMICEC_EVENT_ON_DEVICES_CHANGED "onDevicesChanged"
+#define HDMICEC_EVENT_ON_MESSAGE "onMessage"
+#define HDMICEC_EVENT_ON_HDMI_HOT_PLUG "onHdmiHotPlug"
+#define HDMICEC_EVENT_ON_CEC_ADDRESS_CHANGE "cecAddressesChanged"
+
+#define PHYSICAL_ADDR_CHANGED 1
+#define LOGICAL_ADDR_CHANGED 2
+#define DEV_TYPE_TUNER 1
+
+#define HDMI_HOT_PLUG_EVENT_CONNECTED 0
+#define HDMI_HOT_PLUG_EVENT_DISCONNECTED 1
+
+#if defined(HAS_PERSISTENT_IN_HDD)
+#define CEC_SETTING_ENABLED_FILE "/tmp/mnt/diska3/persistent/ds/cecData.json"
+#elif defined(HAS_PERSISTENT_IN_FLASH)
+#define CEC_SETTING_ENABLED_FILE "/opt/persistent/ds/cecData.json"
+#else
+#define CEC_SETTING_ENABLED_FILE "/opt/ds/cecData.json"
+#endif
+
+#define CEC_SETTING_ENABLED "cecEnabled"
+
+namespace
+{
+    using namespace WPEFramework;
+
+    inline void requestRescanning(int id)
+    {
+        IARM_Bus_CECHost_ConfigureScan_Param_t param  {};
+        param.needFullUpdate = true;
+        param.scanReasonId = id;
+
+        const IARM_Result_t ret = IARM_Bus_Call(IARM_BUS_CECHOST_NAME,
+                                                IARM_BUS_CEC_HOST_ConfigureScan,
+                                                (void *)&param,sizeof(param));
+
+        if (IARM_RESULT_SUCCESS != ret)
+        {
+            LOGERR("%s failed result %d", IARM_BUS_CEC_HOST_ConfigureScan, ret);
+        }
+    }
+    inline void setOsdName(const string& name)
+    {
+        IARM_Bus_CECHost_SetOSDName_Param_t param {};
+
+        strncpy((char *)param.name, name.c_str(), sizeof(param.name));
+        param.name[sizeof(param.name) - 1] = '\0';
+        const IARM_Result_t ret = IARM_Bus_Call(IARM_BUS_CECHOST_NAME,
+                                                IARM_BUS_CEC_HOST_SetOSDName,
+                                                (void *)&param,
+                                                sizeof(param));
+        if (IARM_RESULT_SUCCESS != ret)
+        {
+            LOGERR("%s failed result %d", IARM_BUS_CEC_HOST_SetOSDName, ret);
+        }
+    }
+}
+
+namespace WPEFramework
+{
+    namespace Plugin
+    {
+        SERVICE_REGISTRATION(LgiHdmiCec, 1, 0);
+
+        LgiHdmiCec* LgiHdmiCec::_instance = nullptr;
+
+        static std::atomic<int> libcecInitStatus{0};
+
+        LgiHdmiCec::LgiHdmiCec()
+        : AbstractPlugin(),
+            cecSettingEnabled(false),cecEnableStatus(false),smConnection(nullptr),
+            m_scan_id(0), m_updated(false), m_rescan_in_progress(true), m_system_audio_mode(false)
+        {
+            LgiHdmiCec::_instance = this;
+
+            InitializeIARM();
+            device::Manager::Initialize();
+
+            registerMethod(HDMICEC_METHOD_SET_ENABLED, &LgiHdmiCec::setEnabledWrapper, this);
+            registerMethod(HDMICEC_METHOD_GET_ENABLED, &LgiHdmiCec::getEnabledWrapper, this);
+            registerMethod(HDMICEC_METHOD_GET_CEC_ADDRESSES, &LgiHdmiCec::getCECAddressesWrapper, this);
+            registerMethod(HDMICEC_METHOD_SEND_MESSAGE, &LgiHdmiCec::sendMessageWrapper, this);
+            registerMethod(HDMICEC_METHOD_ENABLE_ONE_TOUCH_VIEW, &LgiHdmiCec::enableOneTouchViewWrapper, this);
+            registerMethod(HDMICEC_METHOD_TRIGGER_ACTION, &LgiHdmiCec::triggerActionWrapper, this);
+            registerMethod(HDMICEC_METHOD_SET_PING_INTERVAL, &LgiHdmiCec::setPingIntervalWrapper, this);
+            registerMethod(HDMICEC_METHOD_GET_CONNECTED_DEVICES, &LgiHdmiCec::getConnectedDevicesWrapper, this);
+            registerMethod(HDMICEC_METHOD_SET_NAME, &LgiHdmiCec::setNameWrapper, this);
+            registerMethod(HDMICEC_METHOD_SET_ONE_TOUCH_VIEW_POLICY, &LgiHdmiCec::setOneTouchViewPolicyWrapper, this);
+
+            physicalAddress = 0x0F0F0F0F;
+
+            logicalAddressDeviceType = "None";
+            logicalAddress = 0xFF;
+
+            loadSettings();
+            if (cecSettingEnabled)
+            {
+                setEnabled(cecSettingEnabled);
+            }
+            else
+            {
+                setEnabled(false);
+                Utils::persistJsonSettings (CEC_SETTING_ENABLED_FILE, CEC_SETTING_ENABLED, JsonValue(false));
+            }
+
+            m_scan_id++;
+            requestRescanning(m_scan_id);
+        }
+
+        LgiHdmiCec::~LgiHdmiCec()
+        {
+        }
+
+        void LgiHdmiCec::Deinitialize(PluginHost::IShell* /* service */)
+        {
+            CECDisable();
+            LgiHdmiCec::_instance = nullptr;
+
+            DeinitializeIARM();
+
+        }
+
+        const void LgiHdmiCec::InitializeIARM()
+        {
+            if (Utils::IARM::init())
+            {
+                IARM_Result_t res;
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_DAEMON_INITIALIZED,cecMgrEventHandler) );
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_STATUS_UPDATED,cecMgrEventHandler) );
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG, dsHdmiEventHandler) );
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_CECHOST_NAME, IARM_BUS_CECHost_EVENT_DEVICESTATUSCHANGE, cecHostDeviceStatusChangedEventHandler) );
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_CECHOST_NAME, IARM_BUS_CECHost_EVENT_DEVICESTATUSUPDATEEND, cecHostDeviceStatusUpdateEndEventHandler) );
+            }
+        }
+
+        void LgiHdmiCec::DeinitializeIARM()
+        {
+            if (Utils::IARM::isConnected())
+            {
+                IARM_Result_t res;
+                IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_DAEMON_INITIALIZED) );
+                IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_STATUS_UPDATED) );
+                IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG) );
+                IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_CECHOST_NAME, IARM_BUS_CECHost_EVENT_DEVICESTATUSCHANGE) );
+                IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_CECHOST_NAME, IARM_BUS_CECHost_EVENT_DEVICESTATUSUPDATEEND) );
+            }
+        }
+
+        void LgiHdmiCec::cecMgrEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+        {
+            if(!LgiHdmiCec::_instance)
+                return;
+
+            if( !strcmp(owner, IARM_BUS_CECMGR_NAME))
+            {
+                switch (eventId)
+                {
+                    case IARM_BUS_CECMGR_EVENT_DAEMON_INITIALIZED:
+                    {
+                        LgiHdmiCec::_instance->onCECDaemonInit();
+                    }
+                    break;
+                    case IARM_BUS_CECMGR_EVENT_STATUS_UPDATED:
+                    {
+                        IARM_Bus_CECMgr_Status_Updated_Param_t *evtData = new IARM_Bus_CECMgr_Status_Updated_Param_t;
+                        if(evtData)
+                        {
+                            memcpy(evtData,data,sizeof(IARM_Bus_CECMgr_Status_Updated_Param_t));
+                            LgiHdmiCec::_instance->cecStatusUpdated(evtData);
+                        }
+                    }
+                    break;
+                    default:
+                    /*Do nothing*/
+                    break;
+                }
+            }
+        }
+
+        void LgiHdmiCec::dsHdmiEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+        {
+            if(!LgiHdmiCec::_instance)
+                return;
+
+            if (IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG == eventId)
+            {
+                IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+                int hdmi_hotplug_event = eventData->data.hdmi_hpd.event;
+                LOGINFO("Received IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG  event data:%d \r\n", hdmi_hotplug_event);
+
+                LgiHdmiCec::_instance->onHdmiHotPlug(hdmi_hotplug_event);
+            }
+        }
+
+        void LgiHdmiCec::onCECDaemonInit()
+        {
+            if(true == getEnabled())
+            {
+                setEnabled(false);
+                setEnabled(true);
+            }
+            else
+            {
+                /*Do nothing as CEC is not already enabled*/
+            }
+        }
+
+        void LgiHdmiCec::cecStatusUpdated(void *evtStatus)
+        {
+            IARM_Bus_CECMgr_Status_Updated_Param_t *evtData = (IARM_Bus_CECMgr_Status_Updated_Param_t *)evtStatus;
+            if(evtData)
+            {
+               try{
+                    getPhysicalAddress();
+
+                    unsigned int logicalAddr = evtData->logicalAddress;
+                    std::string logicalAddrDeviceType = DeviceType(LogicalAddress(evtData->logicalAddress).getType()).toString().c_str();
+
+                    LOGWARN("cecLogicalAddressUpdated: logical address updated: %d , saved : %d ", logicalAddr, logicalAddress);
+                    if (logicalAddr != logicalAddress || logicalAddrDeviceType != logicalAddressDeviceType)
+                    {
+                        logicalAddress = logicalAddr;
+                        logicalAddressDeviceType = logicalAddrDeviceType;
+                        cecAddressesChanged(LOGICAL_ADDR_CHANGED);
+                    }
+                }
+                catch (const std::exception& e)
+                {
+                    LOGWARN("CEC exception caught from cecStatusUpdated: %s", e.what());
+                }
+
+                delete evtData;
+            }
+           return;
+        }
+
+        void LgiHdmiCec::onHdmiHotPlug(int connectStatus)
+        {
+            LOGINFO("Status %d", connectStatus);
+            {
+                std::lock_guard<std::mutex> guard(m_mutex);
+                m_devices.clear();
+                m_scan_devices.clear();
+                m_rescan_in_progress = true;
+            }
+            if ((HDMI_HOT_PLUG_EVENT_CONNECTED == connectStatus) && cecEnableStatus)
+            {
+                try
+                {
+                    readAddresses();
+                }
+                catch (const std::exception& e)
+                {
+                    LOGWARN("CEC addresses not present: %s", e.what());
+                }
+                m_scan_id++;
+                requestRescanning(m_scan_id);
+            }
+            if (HDMI_HOT_PLUG_EVENT_DISCONNECTED == connectStatus)
+            {
+                physicalAddress = 0x0F0F0F0F;
+                logicalAddress = 0xFF;
+                logicalAddressDeviceType = "None";
+                cecAddressesChanged(PHYSICAL_ADDR_CHANGED);
+                //avoid race - we can receive update just after hotplug
+                // and before re-scan
+                m_updated = false;
+
+                onDevicesChanged();
+            }
+            return;
+        }
+
+        uint32_t LgiHdmiCec::setEnabledWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+
+            const char *parameterName = "enabled";
+            returnIfBooleanParamNotFound(parameters, parameterName);
+            bool enabled = false;
+            getBoolParameter(parameterName, enabled);
+
+            setEnabled(enabled);
+            returnResponse(true);
+        }
+
+        uint32_t LgiHdmiCec::getEnabledWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+
+            response["enabled"] = getEnabled();
+            returnResponse(true);
+        }
+
+        uint32_t LgiHdmiCec::getCECAddressesWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+
+            response["CECAddresses"] = getCECAddresses();
+
+            returnResponse(true);
+        }
+
+        uint32_t LgiHdmiCec::sendMessageWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+
+            std::string message;
+
+            if (parameters.HasLabel("message"))
+            {
+                message = parameters["message"].String();
+            }
+            else
+            {
+                returnResponse(false);
+            }
+
+            sendMessage(message);
+            returnResponse(true);
+        }
+
+        uint32_t LgiHdmiCec::enableOneTouchViewWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFO();
+
+            const char *parameterName = "enabled";
+            returnIfBooleanParamNotFound(parameters, parameterName);
+
+            IARM_Bus_CECHost_EnableOneTouchView_Param_t param;
+            getBoolParameter(parameterName, param.enableOneTouchView);
+
+            const IARM_Result_t ret = IARM_Bus_Call(IARM_BUS_CECHOST_NAME,
+                                                    (char *)IARM_BUS_CEC_HOST_EnableOneTouchView,
+                                                    (void *)&param, sizeof(param));
+            if (ret != IARM_RESULT_SUCCESS)
+            {
+                LOGERR("Enabling one touch view failed.");
+                returnResponse(false);
+            }
+
+            LOGINFO("Successfully %s one touch view.",
+                    param.enableOneTouchView ? "enabled": "disabled");
+            returnResponse(true);
+        }
+
+        uint32_t LgiHdmiCec::triggerActionWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFO();
+
+            const char *parameterName = "actionName";
+            returnIfStringParamNotFound(parameters, parameterName);
+
+            string actionName;
+            getStringParameter(parameterName, actionName);
+
+            LOGINFO("CEC: %s Triggering action[%s]\n", __FUNCTION__, actionName.c_str());
+
+            IARM_Bus_CECHost_TriggerAction_Param_t param;
+            strncpy(param.name,
+                    actionName.c_str(),
+                    sizeof(param.name));
+            param.name[sizeof(param.name) - 1] = '\0';
+            param.destination = 0x0F;
+
+            const IARM_Result_t ret = IARM_Bus_Call(IARM_BUS_CECHOST_NAME,
+                                                    IARM_BUS_CEC_HOST_TriggerAction,
+                                                    static_cast<void*>(&param), sizeof(param));
+
+            if (IARM_RESULT_SUCCESS != ret)
+            {
+                LOGERR("CEC: ERROR - %s CALL[%s], ACTION[%s] failed result %d\n",
+                       __FUNCTION__,
+                       IARM_BUS_CEC_HOST_TriggerAction,
+                       actionName.c_str(),
+                       ret);
+                returnResponse(false);
+            }
+
+            LOGINFO("CEC: SUCCESS - %s CALL[%s], ACTION[%s]\n", __FUNCTION__, IARM_BUS_CEC_HOST_TriggerAction,
+                    actionName.c_str());
+
+            returnResponse(true);
+        }
+
+        uint32_t LgiHdmiCec::setPingIntervalWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFO();
+
+            const char *parameterName = "intervalSeconds";
+
+            returnIfNumberParamNotFound(parameters, parameterName);
+
+            IARM_Bus_CECHost_SetScanInterval_Param_t param;
+            getNumberParameter(parameterName, param.intervalSeconds);
+
+            const IARM_Result_t ret = IARM_Bus_Call(IARM_BUS_CECHOST_NAME,
+                                                    IARM_BUS_CEC_HOST_SetScanInterval,
+                                                    static_cast<void*>(&param),
+                                                    sizeof(param));
+            if (IARM_RESULT_SUCCESS != ret)
+            {
+                LOGERR("CEC: ERROR - %s %s failed result %d\n",
+                       __FUNCTION__, IARM_BUS_CEC_HOST_SetScanInterval, ret);
+                returnResponse(false);
+            }
+            LOGINFO("CEC: %s  interval %d succeed\n", __FUNCTION__, param.intervalSeconds);
+
+            returnResponse(true);
+        }
+
+        void LgiHdmiCec::onDevicesChanged()
+        {
+            LOGINFO();
+
+            JsonArray deviceList;
+            getConnectedDevices(deviceList);
+            JsonObject parameters;
+            parameters["devices"] = deviceList;
+            sendNotify(HDMICEC_EVENT_ON_DEVICES_CHANGED, parameters);
+        }
+
+        void LgiHdmiCec::getConnectedDevices(JsonArray &deviceList)
+        {
+            LOGINFO();
+            bool connected = false;
+            try
+            {
+                device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+                connected = vPort.isDisplayConnected();
+            }
+            catch (const std::exception& e)
+            {
+                LOGWARN("Checking HDMI0 display connection state failed: %s", e.what());
+            }
+
+            if (!connected)
+            {
+                LOGINFO("HDMI disconnected - empty devices list");
+
+                return;
+            }
+
+            try
+            {
+                std::lock_guard<std::mutex> guard(m_mutex);
+                for (m_devices_map_t::iterator itr = m_devices.begin(); itr != m_devices.end();++itr)
+                {
+                    JsonObject device;
+                    device["vendorId"] = (*itr).second.vendor_id;
+                    device["osdName"] =  (*itr).second.osdName;
+                    device["power"] = (*itr).second.power_state;
+                    device["connected"] =  (*itr).second.connected;
+                    device["device"] = (*itr).first;
+                    deviceList.Add(device);
+                    LOGINFO("CEC: added device: vendorid '%s' name '%s' power %d conn %d dev '%s'\n",
+                            (*itr).second.vendor_id.c_str(),
+                            (*itr).second.osdName.c_str(),
+                            static_cast<int>((*itr).second.power_state),
+                            static_cast<int>((*itr).second.connected),
+                            (*itr).first.c_str());
+                }
+            }
+            catch (const std::exception& e)
+            {
+                LOGWARN("failed: %s", e.what());
+            }
+        }
+
+        uint32_t LgiHdmiCec::getConnectedDevicesWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFO();
+
+            JsonArray deviceList;
+
+            if(cecEnableStatus == true)
+            {
+                getConnectedDevices(deviceList);
+                // force sending onDeviceChanged event on next scan end
+                m_updated = (m_updated || (deviceList.IsNull() && m_rescan_in_progress));
+            }
+            else
+            {
+                LOGERR("CEC: %s failed - CEC disabled\n", __FUNCTION__);
+            }
+            response["devices"] = deviceList;
+            response["systemAudioMode"] = static_cast<bool>(m_system_audio_mode);
+
+            returnResponse(deviceList.IsSet() || (m_rescan_in_progress == false));
+        }
+
+        uint32_t LgiHdmiCec::setNameWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFO();
+
+            string name;
+
+            returnIfStringParamNotFound(parameters, "name");
+            getStringParameter("name", name);
+
+            LOGINFO("%s", name.c_str());
+
+            try
+            {
+                setOsdName(name);
+            }
+            catch (const std::exception& e)
+            {
+                LOGWARN("failed: %s", e.what());
+                returnResponse(false);
+            }
+            returnResponse(true);
+        }
+
+        uint32_t LgiHdmiCec::setOneTouchViewPolicyWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFO();
+
+            returnIfBooleanParamNotFound(parameters, "turnOffAllDevices");
+            bool turnOffAllDevices = true;
+            getBoolParameter("turnOffAllDevices", turnOffAllDevices);
+
+            LOGINFO("turnOffDevices[%s]\n", turnOffAllDevices?"TRUE":"FALSE");
+
+            IARM_Bus_CECHost_SetOneTouchViewPolicy_Param_t param;
+            param.turnOffAllDevices = turnOffAllDevices;
+            const IARM_Result_t ret = IARM_Bus_Call(IARM_BUS_CECHOST_NAME,
+                                                    IARM_BUS_CEC_HOST_SetOneTouchViewPolicy,
+                                                    static_cast<void*>(&param),
+                                                    sizeof(param));
+
+            if (IARM_RESULT_SUCCESS != ret)
+            {
+                LOGERR("%s failed result %d\n",
+                       IARM_BUS_CEC_HOST_SetOneTouchViewPolicy,
+                       ret);
+                returnResponse(false);
+            }
+
+            LOGINFO("SUCCESS - %s\n", IARM_BUS_CEC_HOST_SetOneTouchViewPolicy);
+            returnResponse(true);
+        }
+
+        bool LgiHdmiCec::loadSettings()
+        {
+            Core::File file;
+            file = CEC_SETTING_ENABLED_FILE;
+
+            if (!file.Open())
+            {
+                return false;
+            }
+
+            JsonObject parameters;
+            parameters.IElement::FromFile(file);
+
+            file.Close();
+
+            getBoolParameter(CEC_SETTING_ENABLED, cecSettingEnabled);
+
+            return cecSettingEnabled;
+        }
+
+        void LgiHdmiCec::setEnabled(bool enabled)
+        {
+           LOGWARN("Entered setEnabled ");
+
+           if (cecSettingEnabled != enabled)
+           {
+               Utils::persistJsonSettings (CEC_SETTING_ENABLED_FILE, CEC_SETTING_ENABLED, JsonValue(enabled));
+           }
+           if(true == enabled)
+           {
+               CECEnable();
+           }
+           else
+           {
+               CECDisable();
+           }
+           return;
+        }
+
+        void LgiHdmiCec::CECEnable(void)
+        {
+            LOGWARN("Entered CECEnable");
+            if (cecEnableStatus)
+            {
+                LOGWARN("CEC Already Enabled");
+                return;
+            }
+
+            if(0 == libcecInitStatus)
+            {
+                try
+                {
+                    LibCCEC::getInstance().init();
+                }
+                catch (const std::exception e)
+                {
+                    LOGWARN("CEC exception caught from CECEnable");
+                }
+            }
+            libcecInitStatus++;
+
+            smConnection = new Connection(LogicalAddress::UNREGISTERED,false,"ServiceManager::Connection::");
+            smConnection->open();
+            smConnection->addFrameListener(this);
+
+            //Acquire CEC Addresses
+            getPhysicalAddress();
+            getLogicalAddress();
+
+            cecEnableStatus = true;
+            return;
+        }
+
+        void LgiHdmiCec::CECDisable(void)
+        {
+            LOGWARN("Entered CECDisable ");
+
+            if(!cecEnableStatus)
+            {
+                LOGWARN("CEC Already Disabled ");
+                return;
+            }
+
+            if (smConnection != NULL)
+            {
+                smConnection->close();
+                delete smConnection;
+                smConnection = NULL;
+            }
+            cecEnableStatus = false;
+
+            if(1 == libcecInitStatus)
+            {
+                LibCCEC::getInstance().term();
+            }
+
+            if(libcecInitStatus > 0)
+            {
+                libcecInitStatus--;
+            }
+
+            return;
+        }
+
+        void LgiHdmiCec::readAddresses()
+        {
+            LOGINFO();
+
+            try
+            {
+                device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+                if (vPort.isDisplayConnected())
+                {
+                    if (getPhysicalAddress() || getLogicalAddress())
+                    {
+                        cecAddressesChanged(PHYSICAL_ADDR_CHANGED);
+                    }
+                }
+            }
+            catch (const std::exception& e)
+            {
+                LOGWARN("exception caught: %s", e.what());
+                throw;
+            }
+        }
+
+        bool LgiHdmiCec::getPhysicalAddress()
+        {
+            bool changed = false;
+            LOGINFO("Entered getPhysicalAddress ");
+
+            uint32_t physAddress = 0x0F0F0F0F;
+
+            try {
+                    LibCCEC::getInstance().getPhysicalAddress(&physAddress);
+
+                    LOGINFO("getPhysicalAddress: physicalAddress: %x %x %x %x ", (physAddress >> 24) & 0xFF, (physAddress >> 16) & 0xFF, (physAddress >> 8)  & 0xFF, (physAddress) & 0xFF);
+                    if (physAddress != physicalAddress)
+                    {
+                        physicalAddress = physAddress;
+                        changed = true;
+                    }
+            }
+            catch (const std::exception& e)
+            {
+                LOGWARN("DS exception caught from getPhysicalAddress: %s", e.what());
+                throw;
+            }
+            return changed;
+        }
+
+        bool LgiHdmiCec::getLogicalAddress()
+        {
+            LOGINFO("Entered getLogicalAddress ");
+            bool changed = false;
+
+            try{
+                int addr = LibCCEC::getInstance().getLogicalAddress(DEV_TYPE_TUNER);
+
+                std::string logicalAddrDeviceType = DeviceType(LogicalAddress(addr).getType()).toString().c_str();
+
+                LOGWARN("logical address obtained is %d , saved logical address is %d ", addr, logicalAddress);
+
+                if ((int)logicalAddress != addr || logicalAddressDeviceType != logicalAddrDeviceType)
+
+                {
+                    logicalAddress = addr;
+                    logicalAddressDeviceType = logicalAddrDeviceType;
+                    changed = true;
+                }
+            }
+            catch (const std::exception& e)
+            {
+                LOGWARN("CEC exception caught from getLogicalAddress: %s", e.what());
+                throw;
+            }
+
+            return changed;
+        }
+
+        bool LgiHdmiCec::getEnabled()
+        {
+            LOGWARN("Entered getEnabled ");
+            if(true == cecEnableStatus)
+                return true;
+            else
+                return false;
+        }
+
+        std::string LgiHdmiCec::getName()
+        {
+            //SVCLOG_WARN("%s \r\n",__FUNCTION__);
+            IARM_Result_t ret = IARM_RESULT_INVALID_STATE;
+            if (ret != IARM_RESULT_SUCCESS)
+            {
+                LOGWARN("getName :: IARM_BUS_CEC_HOST_GetOSDName failed ");
+                return "STB";
+            }
+
+            return "STB";
+        }
+
+        JsonObject LgiHdmiCec::getCECAddresses()
+        {
+            JsonObject CECAddress;
+            LOGINFO("Entered getCECAddresses ");
+
+            char pa[32] = {0};
+            snprintf(pa, sizeof(pa), "\\u00%02X\\u00%02X\\u00%02X\\u00%02X", (physicalAddress >> 24) & 0xff, (physicalAddress >> 16) & 0xff, (physicalAddress >> 8) & 0xff, physicalAddress & 0xff);
+
+            CECAddress["physicalAddress"] = (const char *)pa;
+
+            JsonObject logical;
+            logical["deviceType"] = logicalAddressDeviceType;
+            logical["logicalAddress"] = logicalAddress;
+
+            CECAddress["logicalAddresses"] = logical;
+            LOGWARN("getCECAddresses: physicalAddress from QByteArray : %x %x %x %x ", (physicalAddress >> 24) & 0xFF, (physicalAddress >> 16) & 0xFF, (physicalAddress >> 8)  & 0xFF, (physicalAddress) & 0xFF);
+            LOGWARN("getCECAddresses: logical address: %x  ", logicalAddress);
+
+            return CECAddress;
+        }
+
+        // Copy of Core::FromString, which doesn't add extra zero at the end
+        uint16_t LgiHdmiCec::FromBase64String(const string& newValue, uint8_t object[], uint16_t& length, const TCHAR* ignoreList)
+        {
+            uint8_t state = 0;
+            uint16_t index = 0;
+            uint16_t filler = 0;
+            uint8_t lastStuff = 0;
+
+            while ((index < newValue.size()) && (filler < length)) {
+                uint8_t converted;
+                TCHAR current = newValue[index++];
+
+                if ((current >= 'A') && (current <= 'Z')) {
+                    converted = (current - 'A');
+                } else if ((current >= 'a') && (current <= 'z')) {
+                    converted = (current - 'a' + 26);
+                } else if ((current >= '0') && (current <= '9')) {
+                    converted = (current - '0' + 52);
+                } else if (current == '+') {
+                    converted = 62;
+                } else if (current == '/') {
+                    converted = 63;
+                } else if ((ignoreList != nullptr) && (::strchr(ignoreList, current) != nullptr)) {
+                    continue;
+                } else {
+                    break;
+                }
+
+                if (state == 0) {
+                    lastStuff = converted << 2;
+                    state = 1;
+                } else if (state == 1) {
+                    object[filler++] = (((converted & 0x30) >> 4) | lastStuff);
+                    lastStuff = ((converted & 0x0F) << 4);
+                    state = 2;
+                } else if (state == 2) {
+                    object[filler++] = (((converted & 0x3C) >> 2) | lastStuff);
+                    lastStuff = ((converted & 0x03) << 6);
+                    state = 3;
+                } else if (state == 3) {
+                    object[filler++] = ((converted & 0x3F) | lastStuff);
+                    state = 0;
+                }
+            }
+
+            // No need to do this
+            /*if ((state != 0) && (filler < length)) {
+                object[filler++] = lastStuff;
+                LOGINFO("state %d, lastStuff = %d", state, lastStuff);
+            }*/
+
+            length = filler;
+
+            return (index);
+        }
+
+        void LgiHdmiCec::sendMessage(std::string message)
+        {
+            LOGINFO("sendMessage ");
+
+            if(true == cecEnableStatus)
+            {
+                std::vector <unsigned char> buf;
+                buf.resize(message.size());
+
+                uint16_t decodedLen = message.size();
+                FromBase64String(message, (uint8_t*)buf.data(), decodedLen, NULL);
+
+                CECFrame frame = CECFrame((const uint8_t *)buf.data(), decodedLen);
+        //      SVCLOG_WARN("Frame to be sent from servicemanager in %s \n",__FUNCTION__);
+        //      frame.hexDump();
+                smConnection->sendAsync(frame);
+            }
+            else
+                LOGWARN("cecEnableStatus=false");
+            return;
+        }
+
+        void LgiHdmiCec::cecAddressesChanged(int changeStatus)
+        {
+            JsonObject params;
+            JsonObject CECAddresses;
+
+            LOGWARN(" cecAddressesChanged Change Status : %d ", changeStatus);
+            if(PHYSICAL_ADDR_CHANGED == changeStatus)
+            {
+                char pa[32] = {0};
+                snprintf(pa, sizeof(pa), "\\u00%02X\\u00%02X\\u00%02X\\u00%02X", (physicalAddress >> 24) & 0xff, (physicalAddress >> 16) & 0xff, (physicalAddress >> 8) & 0xff, physicalAddress & 0xff);
+
+                CECAddresses["physicalAddress"] = (const char *)pa;
+            }
+            else if(LOGICAL_ADDR_CHANGED == changeStatus)
+            {
+                CECAddresses["logicalAddresses"] = logicalAddress;
+            }
+            else
+            {
+                //Do Nothing
+            }
+
+            params["CECAddresses"] = CECAddresses;
+            LOGWARN(" cecAddressesChanged  send : %s ", HDMICEC_EVENT_ON_CEC_ADDRESS_CHANGE);
+
+            sendNotify(HDMICEC_EVENT_ON_CEC_ADDRESS_CHANGE, params);
+
+            return;
+        }
+
+        void LgiHdmiCec::notify(const CECFrame &in) const
+        {
+            LOGINFO("Inside notify ");
+            size_t length;
+            const uint8_t *input_frameBuf = NULL;
+            CECFrame Frame = in;
+        //  SVCLOG_WARN("Frame received by servicemanager is \n");
+        //  Frame.hexDump();
+            Frame.getBuffer(&input_frameBuf,&length);
+
+            std::vector <char> buf;
+            // base64 encoded string uses 4 characters for every 3 bytes (using padding if necessary) - so assume padding is used
+            // Base64Encode doesn't seem to use base64 padding right now, but better to be future-proof
+            size_t required_buffer_size = 4 * (length / 3);
+            if (length % 3 != 0) required_buffer_size += 4;
+            buf.resize(required_buffer_size + 1); // +1 for null terminator
+
+            uint16_t encodedLen = Core::URL::Base64Encode(input_frameBuf, length, buf.data(), buf.size());
+            buf[encodedLen] = 0;
+
+            (const_cast<LgiHdmiCec*>(this))->onMessage(buf.data());
+            return;
+        }
+
+        void LgiHdmiCec::onMessage( const char *message )
+        {
+            JsonObject params;
+            params["message"] = message;
+            sendNotify(HDMICEC_EVENT_ON_MESSAGE, params);
+        }
+
+        void LgiHdmiCec::onDeviceStatusChanged(IARM_EventId_t eventId, const void* data_ptr, size_t len)
+        {
+            assert(data_ptr != NULL);
+            if (len < sizeof(IARM_Bus_CECHost_DeviceStatusChanged_EventData_t))
+            {
+                return;
+            }
+            const IARM_Bus_CECHost_DeviceStatusChanged_EventData_t* eData = static_cast<const IARM_Bus_CECHost_DeviceStatusChanged_EventData_t*>(data_ptr);
+
+            LOGINFO("id=%d, len=%u", (int)eventId, (unsigned)len);
+
+            if ((eData->logicalAddress == LogicalAddress::TV) || (eData->logicalAddress == LogicalAddress::AUDIO_SYSTEM))
+            { // the scanner may send events for other devices, so skip them ...
+                bool update = false;
+                try
+                {
+                    readAddresses();
+
+                    switch(eData->changedStatus)
+                    {
+                      case IARM_BUS_CECHost_OSD_NAME:
+                      {
+                          LOGINFO("IARM_BUS_CECHost_OSD_NAME for device %d name %s", eData->logicalAddress, eData->data.osdName);
+                          update = setChangedDeviceOsdName(eData->data.osdName, eData->logicalAddress);
+                          break;
+                      }
+                      case IARM_BUS_CECHost_VENDOR_ID:
+                      {
+                          LOGINFO("IARM_BUS_CECHost_VENDOR_ID for device %d vendor id 0x%x", eData->logicalAddress, eData->data.vendorId);
+                          update = setChangedDeviceVendorId(eData->data.vendorId, eData->logicalAddress);
+                          break;
+                      }
+                      case IARM_BUS_CECHost_POWER_STATUS:
+                      {
+                          LOGINFO("IARM_BUS_CECHost_POWER_STATUS for device %d powerState %d", eData->logicalAddress, eData->data.powerState);
+                          update = setChangedDevicePowerState(eData->data.powerState, eData->logicalAddress);
+                          break;
+                      }
+                      case IARM_BUS_CECHost_CONNECT_STATUS:
+                      {
+                          LOGINFO("IARM_BUS_CECHost_CONNECT_STATUS for device %d isConnected %d", eData->logicalAddress, eData->data.isConnected);
+                          update = setChangedDeviceConnectedState(eData->data.isConnected, eData->logicalAddress);
+                          break;
+                      }
+                      case IARM_BUS_CECHost_AUDIO_MODE:
+                      {
+                          LOGINFO("IARM_BUS_CECHost_AUDIO_MODE systemAudioMode %d\n", eData->data.systemAudioMode);
+                          update = setChangedDeviceSystemAudioMode(eData->data.systemAudioMode);
+                          break;
+                      }
+                      default:
+                      {
+                          LOGWARN("Unsupported event IARM_BUS_CECHost %d !!!!!", eData->changedStatus);
+                          break;
+                      }
+                    }
+                }
+                catch (const std::exception& e)
+                {
+                    LOGERR("exception caught");
+                }
+                if (update)
+                {
+                    m_updated = true;
+                }
+            }
+            else
+            {
+                LOGWARN("skipped IARM event %d for unknown device %d", eData->changedStatus, eData->logicalAddress);
+            }
+        }
+
+        void LgiHdmiCec::cecHostDeviceStatusChangedEventHandler(const char* owner_str, IARM_EventId_t eventId, void* data_ptr, size_t len)
+        {
+            LOGINFO("owner=%s", owner_str? owner_str: "<<UNKNOWN>>");
+
+            if (!LgiHdmiCec::_instance)
+                return;
+
+            if (data_ptr && owner_str
+                    && (eventId == IARM_BUS_CECHost_EVENT_DEVICESTATUSCHANGE)
+                    && (strcmp(owner_str, IARM_BUS_CECHOST_NAME) == 0))
+            {
+                _instance->onDeviceStatusChanged(eventId, data_ptr, len);
+            }
+        }
+
+        void LgiHdmiCec::onDeviceStatusUpdateEnd(IARM_EventId_t eventId, const void* data_ptr, size_t len)
+        {
+            assert(data_ptr != NULL);
+            if (len < sizeof(IARM_Bus_CECHost_DeviceStatusUpdateEnd_EventData_t))
+            {
+                return;
+            }
+            const IARM_Bus_CECHost_DeviceStatusUpdateEnd_EventData_t* eData = static_cast<const IARM_Bus_CECHost_DeviceStatusUpdateEnd_EventData_t*>(data_ptr);
+
+            LOGINFO("scanId %d(%d) scan finished %d", eData->scanId, m_scan_id.load(), eData->isScanFinished);
+
+            if (eData->isScanFinished != 1)
+            {
+                LOGWARN("scan corrupted scanId %d(%d) scan finished %d", eData->scanId, m_scan_id.load(), eData->isScanFinished);
+                return;
+            }
+
+            if ((m_scan_id > 0) && (m_scan_id != eData->scanId))
+            {
+                LOGWARN("skipped on invalid scan_id %d(%d) scan finished %d", eData->scanId, m_scan_id.load(), eData->isScanFinished);
+            }
+            else
+            {
+                if (m_updated)
+                {
+                    LOGWARN("Update OK, finished (%d) scanId %d(%d)", eData->isScanFinished, eData->scanId, m_scan_id.load());
+                    m_updated = false;
+                    {
+                        std::lock_guard<std::mutex> guard(m_mutex);
+                        m_devices = m_scan_devices;
+                        m_rescan_in_progress = false;
+                    }
+                    onDevicesChanged();
+                }
+                else
+                {
+                    m_rescan_in_progress = false;
+                    LOGWARN("skipped: no changes on devices (empty callback)");
+                }
+            }
+            m_scan_id = 0;
+        }
+
+        void LgiHdmiCec::cecHostDeviceStatusUpdateEndEventHandler(const char* owner_str, IARM_EventId_t eventId, void* data_ptr, size_t len)
+        {
+            LOGINFO("owner=%s", owner_str? owner_str: "<<UNKNOWN>>");
+
+            if (!LgiHdmiCec::_instance)
+                return;
+
+            if (data_ptr && owner_str
+                    && (strcmp(owner_str, IARM_BUS_CECHOST_NAME) == 0))
+            {
+                _instance->onDeviceStatusUpdateEnd(eventId, data_ptr, len);
+            }
+        }
+
+        bool LgiHdmiCec::setChangedDeviceOsdName(const char* name, int logical_address)
+        {
+            assert(name != NULL);
+
+            bool result = false;
+
+            LOGINFO("OSD name: '%s' set for device %d", name, logical_address);
+
+            if ((logical_address >= LogicalAddress::TV) && (logical_address < LogicalAddress::UNREGISTERED))
+            {
+                string dev_type = LogicalAddress(logical_address).toString();
+                std::lock_guard<std::mutex> guard(m_mutex);
+                device_t& device = m_scan_devices[dev_type];
+
+                result = (device.osdName!= name);
+                device.osdName = name;
+                LOGINFO("CEC: OSD NAME:'%s' set for device %s", name, dev_type.c_str());
+            }
+            else
+            {
+                LOGWARN("CEC: device osdName failed - invalid logical address %d", logical_address);
+            }
+            return result;
+        }
+
+        bool LgiHdmiCec::setChangedDeviceVendorId(uint32_t vendor_id, int logical_address)
+        {
+            bool result = false;
+
+            LOGWARN("VendorID: '%u' set for device %d", vendor_id, logical_address);
+
+            string dev_type = LogicalAddress(logical_address).toString();
+            std::lock_guard<std::mutex> guard(m_mutex);
+            device_t& device = m_scan_devices[dev_type];
+            std::ostringstream vendor_id_conv;
+            vendor_id_conv << std::hex << vendor_id;
+            string vendor = vendor_id_conv.str();
+
+            if (device.vendor_id != vendor)
+            {
+                device.vendor_id = vendor;
+                LOGWARN("set vendor id %s for device %d", device.vendor_id.c_str(), logical_address);
+            }
+            else
+            {
+                LOGINFO("skipped device update (the same vendor id 0x%x) for device %d", vendor_id, logical_address);
+            }
+
+            return result;
+        }
+
+        bool LgiHdmiCec::setChangedDeviceConnectedState(int connected, int logical_address)
+        {
+            bool result = false;
+
+            LOGINFO("connected: %d set for device %d", connected, logical_address);
+
+            string dev_type = LogicalAddress(logical_address).toString();
+            std::lock_guard<std::mutex> guard(m_mutex);
+            device_t& device = m_scan_devices[dev_type];
+
+            result = device.connected != ((connected != 0) ? true : false);
+            if (result)
+            {
+                device.connected = (connected != 0);
+                LOGWARN("set connected %d set for %s", connected, dev_type.c_str());
+            }
+
+            return result;
+        }
+
+        bool LgiHdmiCec::setChangedDevicePowerState(int power_state, int logical_address)
+        {
+            bool result = false;
+
+            LOGINFO("power_state: %d set for device %d", power_state, logical_address);
+
+            string dev_type = LogicalAddress(logical_address).toString();
+            std::lock_guard<std::mutex> guard(m_mutex);
+            device_t& device = m_scan_devices[dev_type];
+
+            result = (device.power_state != ((power_state != 0) ? true : false));
+
+            if (result)
+            {
+                device.power_state = (power_state != 0);
+                LOGWARN("set power_state %d for %s", power_state, dev_type.c_str());
+            }
+
+            return result;
+        }
+
+        bool LgiHdmiCec::setChangedDeviceSystemAudioMode(int system_audio_mode)
+        {
+            LOGINFO("system_audio_mode: %d\n", system_audio_mode);
+
+            bool old_value = m_system_audio_mode;
+            m_system_audio_mode = (system_audio_mode != 0);
+
+            return old_value != m_system_audio_mode;
+        }
+
+    } // namespace Plugin
+} // namespace WPEFramework
+
+
+

--- a/LgiHdmiCec/LgiHdmiCec.h
+++ b/LgiHdmiCec/LgiHdmiCec.h
@@ -1,0 +1,151 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2019 RDK Management
+* Copyright 2021 Liberty Global Service B.V.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#pragma once
+
+#include <atomic>
+#include <map>
+#include <mutex>
+#include <stdint.h>
+#include "ccec/FrameListener.hpp"
+#include "ccec/Connection.hpp"
+
+#include "libIBus.h"
+
+#undef Assert // this define from Connection.hpp conflicts with WPEFramework
+
+#include "Module.h"
+#include "utils.h"
+#include "AbstractPlugin.h"
+
+namespace WPEFramework {
+
+    namespace Plugin {
+
+		// This is a server for a JSONRPC communication channel. 
+		// For a plugin to be capable to handle JSONRPC, inherit from PluginHost::JSONRPC.
+		// By inheriting from this class, the plugin realizes the interface PluginHost::IDispatcher.
+		// This realization of this interface implements, by default, the following methods on this plugin
+		// - exists
+		// - register
+		// - unregister
+		// Any other methood to be handled by this plugin  can be added can be added by using the
+		// templated methods Register on the PluginHost::JSONRPC class.
+		// As the registration/unregistration of notifications is realized by the class PluginHost::JSONRPC,
+		// this class exposes a public method called, Notify(), using this methods, all subscribed clients
+		// will receive a JSONRPC message as a notification, in case this method is called.
+        class LgiHdmiCec : public AbstractPlugin, public FrameListener {
+        private:
+
+            // We do not allow this plugin to be copied !!
+            LgiHdmiCec(const LgiHdmiCec&) = delete;
+            LgiHdmiCec& operator=(const LgiHdmiCec&) = delete;
+
+            //Begin methods
+            uint32_t setEnabledWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getEnabledWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getCECAddressesWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t sendMessageWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t enableOneTouchViewWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t triggerActionWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t setPingIntervalWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getConnectedDevicesWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t setNameWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t setOneTouchViewPolicyWrapper(const JsonObject& parameters, JsonObject& response);
+            //End methods
+        public:
+            LgiHdmiCec();
+            virtual ~LgiHdmiCec();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
+
+        public:
+            static LgiHdmiCec* _instance;
+        private:
+            std::string logicalAddressDeviceType;
+            unsigned int logicalAddress;
+            unsigned int physicalAddress;
+            std::atomic_bool cecSettingEnabled;
+            std::atomic_bool cecEnableStatus;
+            Connection *smConnection;
+
+            const void InitializeIARM();
+            void DeinitializeIARM();
+            static void cecMgrEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+            static void dsHdmiEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+            static void cecHostDeviceStatusChangedEventHandler(const char* owner_str, IARM_EventId_t eventId, void* data_ptr, size_t len);
+            static void cecHostDeviceStatusUpdateEndEventHandler(const char* owner_str, IARM_EventId_t eventId, void* data_ptr, size_t len);
+            void onCECDaemonInit();
+            void cecStatusUpdated(void *evtStatus);
+            void onHdmiHotPlug(int connectStatus);
+            void onDeviceStatusChanged(IARM_EventId_t eventId, const void* data_ptr, size_t len);
+            void onDeviceStatusUpdateEnd(IARM_EventId_t eventId, const void* data_ptr, size_t len);
+            void onDevicesChanged();
+
+            void getConnectedDevices(JsonArray &deviceList);
+
+            bool setChangedDeviceOsdName(const char* name, int logical_address);
+            bool setChangedDeviceVendorId(uint32_t vendor_id, int logical_address);
+            bool setChangedDeviceConnectedState(int connected, int logical_address);
+            bool setChangedDevicePowerState(int power_state, int logical_address);
+            bool setChangedDeviceSystemAudioMode(int system_audio_mode);
+
+            bool loadSettings();
+
+            void persistSettings(bool enableStatus);
+            void setEnabled(bool enabled);
+            void CECEnable(void);
+            void CECDisable(void);
+            bool getPhysicalAddress();
+            bool getLogicalAddress();
+            void readAddresses();
+            bool getEnabled();
+            std::string getName();
+            JsonObject getCECAddresses();
+
+            uint16_t FromBase64String(const string& newValue, uint8_t object[], uint16_t& length, const TCHAR* ignoreList);
+            void sendMessage(std::string message);
+            void cecAddressesChanged(int changeStatus);
+
+            void notify(const CECFrame &in) const;
+            void onMessage(const char *message);
+
+            std::atomic<int> m_scan_id;
+            std::atomic_bool m_updated;
+            std::atomic_bool m_rescan_in_progress;
+            std::atomic_bool m_system_audio_mode;
+
+            typedef struct device_s
+            {
+                std::string physical_address;
+                std::string osdName;
+                std::string vendor_id;
+                bool connected = false;
+                bool power_state = true;
+            } device_t;
+
+            typedef std::map<std::string, device_t> m_devices_map_t;
+            m_devices_map_t m_devices;
+            m_devices_map_t m_scan_devices;
+            std::mutex m_mutex;
+        };
+    } // namespace Plugin
+} // namespace WPEFramework
+
+

--- a/LgiHdmiCec/LgiHdmiCec.json
+++ b/LgiHdmiCec/LgiHdmiCec.json
@@ -1,0 +1,186 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rdkcentral/Thunder/master/Tools/JsonGenerator/schemas/interface.schema.json",
+    "jsonrpc": "2.0",
+    "info": {
+        "title": "LgiHdmiCec API", 
+        "class": "LgiHdmiCec", 
+        "description": "The `LgiHdmiCec` plugin allows you to configure HDMI Consumer Electronics Control (CEC) on a set-top box"
+    },
+    "definitions": {
+        "enabled": {
+            "summary": "Indicates whether HDMI-CEC is enabled (`true`) or disabled (`false`)",
+            "type":"boolean",
+            "example": false
+        },
+        "physicalAddress":{
+            "summary": "The physical IP address of the device",
+            "type":"array",
+            "items": {
+                "type": "string",
+                "example": "255, 255, 255, 255"
+            }
+        },
+        "message":{
+            "summary": "The message is a base64 encoded byte array of the raw CEC bytes. The CEC message includes the device ID for the intended destination.",
+            "type": "string",
+            "example": "1234567890" 
+        },
+        "result": {
+            "type":"object",
+            "properties": {
+                "success": {
+                    "$ref": "#/definitions/success"
+                }
+            },
+            "required": [
+                "success"
+            ]
+        },
+        "success": {
+            "summary": "Whether the request succeeded",
+            "type": "boolean",
+            "example": "true"
+        }
+    },
+    "methods": {
+        "getCECAddresses":{
+            "summary": "Returns the HDMI-CEC addresses that are assigned to the local device",
+            "result": {
+                "type": "object",
+                "properties": {
+                    "CECAddresses": {
+                        "summary": "An object that includes both the physical and logical HDMI-CEC addresses.",
+                        "type":"object",
+                        "properties": {
+                            "physicalAddress":{
+                                "$ref": "#/definitions/physicalAddress"
+                            },
+                            "logicalAddresses":{
+                                "summary": "The logical address including the device type",
+                                "type": "array",
+                                "items": {
+                                    "type":"object",
+                                    "properties": {
+                                        "deviceType": {
+                                            "summary": "The type of device",
+                                            "type": "string",
+                                            "example": "Tuner"
+                                        },
+                                        "logicalAddress": {
+                                            "summary": "The logical address of the device",
+                                            "type": "integer",
+                                            "example": 3
+                                        }
+                                    },
+                                    "required": [
+                                        "deviceType",
+                                        "logicalAddress"
+                                    ]
+                                }
+                            }
+                        },
+                        "required": [
+                            "physicalAddress",
+                            "logicalAddresses"
+                        ]
+                    },
+                    "success": {
+                        "$ref": "#/definitions/success"
+                    }
+                },
+                "required": [
+                    "CECAddresses",
+                    "success"
+                ]
+            }
+        },
+        "getEnabled": {
+            "summary": "Returns whether HDMI-CEC is enabled",
+            "result": {
+                "type": "object",
+                "properties": {
+                    "enabled": {
+                        "$ref": "#/definitions/enabled"
+                    },
+                    "success": {
+                        "$ref": "#/definitions/success"
+                    }
+                },
+                "required": [
+                    "enabled",
+                    "success"
+                ]
+            }
+        },
+        "sendMessage":{
+            "summary": "Writes HDMI-CEC frame to the driver",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "message":{
+                        "$ref": "#/definitions/message"
+                    }
+                },
+                "required": [
+                    "message"
+                ]
+            },
+            "result": {
+                "$ref": "#/definitions/result"
+            }
+        },
+        "setEnabled":{
+            "summary": "Enables or disables HDMI-CEC",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "enabled":{
+                        "$ref": "#/definitions/enabled" 
+                    }
+                },
+                "required": [
+                    "enabled"
+                ]
+            },
+            "result": {
+                "$ref": "#/definitions/result"
+            }
+        }
+    },
+    "events": {
+        "cecAddressesChanged":{
+            "summary": "Triggered when the address of the host CEC device has changed",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "CECAddresses": {
+                        "summary": "Includes either the `physicalAddress` or `logicalAddresses`",
+                        "type":"object",
+                        "properties": {
+                            "physicalAddress":{
+                                "$ref": "#/definitions/physicalAddress"
+                            }
+                        }
+                    }
+                },
+                "required": [
+                    "CECAddresses"
+                ]
+            }
+        },
+        "onMessage":{
+            "summary": "Triggered when a message is sent from an HDMI device",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "message": {
+                        "$ref": "#/definitions/message"
+                    }
+                },
+                "required": [
+                    "message"
+                ]
+            }
+        }
+    }
+}

--- a/LgiHdmiCec/LgiHdmiCecPlugin.json
+++ b/LgiHdmiCec/LgiHdmiCecPlugin.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rdkcentral/Thunder/master/Tools/JsonGenerator/schemas/plugin.schema.json",
+    "info": {
+      "title": "LgiHdmiCecPlugin",
+      "callsign": "com.lgi.rdk.HdmiCec",
+      "locator": "libWPEFrameworkLgiHdmiCec.so",
+      "status": "production",
+      "description": "The `LgiHdmiCec` plugin allows you to configure HDMI Consumer Electronics Control (CEC) on a set-top box.",
+      "version": "1.0"
+    },
+    "interface": {
+      "$ref": "LgiHdmiCec.json#"
+    }
+}

--- a/LgiHdmiCec/Module.cpp
+++ b/LgiHdmiCec/Module.cpp
@@ -1,0 +1,23 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2019 RDK Management
+* Copyright 2021 Liberty Global Service B.V.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#include "Module.h"
+
+MODULE_NAME_DECLARATION(BUILD_REFERENCE)

--- a/LgiHdmiCec/Module.h
+++ b/LgiHdmiCec/Module.h
@@ -1,0 +1,30 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2019 RDK Management
+* Copyright 2021 Liberty Global Service B.V.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#pragma once
+#ifndef MODULE_NAME
+#define MODULE_NAME Plugin_LgiHdmiCec
+#endif
+
+#include <plugins/plugins.h>
+#include <tracing/tracing.h>
+
+#undef EXTERNAL
+#define EXTERNAL

--- a/LgiHdmiCec/README.md
+++ b/LgiHdmiCec/README.md
@@ -1,0 +1,9 @@
+-----------------
+Build:
+
+bitbake wpeframework-service-plugins
+
+-----------------
+Test:
+
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0","id":"3","method": "HdmiCec.1."}' http://127.0.0.1:9998/jsonrpc

--- a/LgiHdmiCec/doc/LgiHdmiCecPlugin.md
+++ b/LgiHdmiCec/doc/LgiHdmiCecPlugin.md
@@ -1,0 +1,354 @@
+<!-- Generated automatically, DO NOT EDIT! -->
+<a name="head.HdmiCecPlugin"></a>
+# HdmiCecPlugin
+
+**Version: 1.0**
+
+**Status: :black_circle::black_circle::black_circle:**
+
+org.rdk.HdmiCec plugin for Thunder framework.
+
+### Table of Contents
+
+- [Introduction](#head.Introduction)
+- [Description](#head.Description)
+- [Configuration](#head.Configuration)
+- [Methods](#head.Methods)
+- [Notifications](#head.Notifications)
+
+<a name="head.Introduction"></a>
+# Introduction
+
+<a name="head.Scope"></a>
+## Scope
+
+This document describes purpose and functionality of the org.rdk.HdmiCec plugin. It includes detailed specification about its configuration, methods provided and notifications sent.
+
+<a name="head.Case_Sensitivity"></a>
+## Case Sensitivity
+
+All identifiers of the interfaces described in this document are case-sensitive. Thus, unless stated otherwise, all keywords, entities, properties, relations and actions should be treated as such.
+
+<a name="head.Acronyms,_Abbreviations_and_Terms"></a>
+## Acronyms, Abbreviations and Terms
+
+The table below provides and overview of acronyms used in this document and their definitions.
+
+| Acronym | Description |
+| :-------- | :-------- |
+| <a name="acronym.API">API</a> | Application Programming Interface |
+| <a name="acronym.HTTP">HTTP</a> | Hypertext Transfer Protocol |
+| <a name="acronym.JSON">JSON</a> | JavaScript Object Notation; a data interchange format |
+| <a name="acronym.JSON-RPC">JSON-RPC</a> | A remote procedure call protocol encoded in JSON |
+
+The table below provides and overview of terms and abbreviations used in this document and their definitions.
+
+| Term | Description |
+| :-------- | :-------- |
+| <a name="term.callsign">callsign</a> | The name given to an instance of a plugin. One plugin can be instantiated multiple times, but each instance the instance name, callsign, must be unique. |
+
+<a name="head.References"></a>
+## References
+
+| Ref ID | Description |
+| :-------- | :-------- |
+| <a name="ref.HTTP">[HTTP](http://www.w3.org/Protocols)</a> | HTTP specification |
+| <a name="ref.JSON-RPC">[JSON-RPC](https://www.jsonrpc.org/specification)</a> | JSON-RPC 2.0 specification |
+| <a name="ref.JSON">[JSON](http://www.json.org/)</a> | JSON specification |
+| <a name="ref.Thunder">[Thunder](https://github.com/WebPlatformForEmbedded/Thunder/blob/master/doc/WPE%20-%20API%20-%20WPEFramework.docx)</a> | Thunder API Reference |
+
+<a name="head.Description"></a>
+# Description
+
+The `HdmiCec` plugin allows you to configure HDMI Consumer Electronics Control (CEC) on a set-top box.
+
+The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#ref.Thunder)].
+
+<a name="head.Configuration"></a>
+# Configuration
+
+The table below lists configuration options of the plugin.
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| callsign | string | Plugin instance name (default: *org.rdk.HdmiCec*) |
+| classname | string | Class name: *org.rdk.HdmiCec* |
+| locator | string | Library name: *libWPEFrameworkHdmiCec.so* |
+| autostart | boolean | Determines if the plugin shall be started automatically along with the framework |
+
+<a name="head.Methods"></a>
+# Methods
+
+The following methods are provided by the org.rdk.HdmiCec plugin:
+
+HdmiCec interface methods:
+
+| Method | Description |
+| :-------- | :-------- |
+| [getCECAddresses](#method.getCECAddresses) | Returns the HDMI-CEC addresses that are assigned to the local device |
+| [getEnabled](#method.getEnabled) | Returns whether HDMI-CEC is enabled |
+| [sendMessage](#method.sendMessage) | Writes HDMI-CEC frame to the driver |
+| [setEnabled](#method.setEnabled) | Enables or disables HDMI-CEC |
+
+
+<a name="method.getCECAddresses"></a>
+## *getCECAddresses <sup>method</sup>*
+
+Returns the HDMI-CEC addresses that are assigned to the local device.
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.CECAddresses | object | An object that includes both the physical and logical HDMI-CEC addresses |
+| result.CECAddresses.physicalAddress | array | The physical IP address of the device |
+| result.CECAddresses.physicalAddress[#] | string |  |
+| result.CECAddresses.logicalAddresses | array | The logical address including the device type |
+| result.CECAddresses.logicalAddresses[#] | object |  |
+| result.CECAddresses.logicalAddresses[#].deviceType | string | The type of device |
+| result.CECAddresses.logicalAddresses[#].logicalAddress | integer | The logical address of the device |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "org.rdk.HdmiCec.1.getCECAddresses"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": {
+        "CECAddresses": {
+            "physicalAddress": [
+                "255, 255, 255, 255"
+            ],
+            "logicalAddresses": [
+                {
+                    "deviceType": "Tuner",
+                    "logicalAddress": 3
+                }
+            ]
+        },
+        "success": true
+    }
+}
+```
+
+<a name="method.getEnabled"></a>
+## *getEnabled <sup>method</sup>*
+
+Returns whether HDMI-CEC is enabled.
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.enabled | boolean | Indicates whether HDMI-CEC is enabled (`true`) or disabled (`false`) |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "org.rdk.HdmiCec.1.getEnabled"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": {
+        "enabled": false,
+        "success": true
+    }
+}
+```
+
+<a name="method.sendMessage"></a>
+## *sendMessage <sup>method</sup>*
+
+Writes HDMI-CEC frame to the driver.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.message | string | The message is a base64 encoded byte array of the raw CEC bytes. The CEC message includes the device ID for the intended destination |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "org.rdk.HdmiCec.1.sendMessage",
+    "params": {
+        "message": "1234567890"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": {
+        "success": true
+    }
+}
+```
+
+<a name="method.setEnabled"></a>
+## *setEnabled <sup>method</sup>*
+
+Enables or disables HDMI-CEC.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.enabled | boolean | Indicates whether HDMI-CEC is enabled (`true`) or disabled (`false`) |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "org.rdk.HdmiCec.1.setEnabled",
+    "params": {
+        "enabled": false
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": {
+        "success": true
+    }
+}
+```
+
+<a name="head.Notifications"></a>
+# Notifications
+
+Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.
+
+The following events are provided by the org.rdk.HdmiCec plugin:
+
+HdmiCec interface events:
+
+| Event | Description |
+| :-------- | :-------- |
+| [cecAddressesChanged](#event.cecAddressesChanged) | Triggered when the address of the host CEC device has changed |
+| [onMessage](#event.onMessage) | Triggered when a message is sent from an HDMI device |
+
+
+<a name="event.cecAddressesChanged"></a>
+## *cecAddressesChanged <sup>event</sup>*
+
+Triggered when the address of the host CEC device has changed.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.CECAddresses | object | Includes either the `physicalAddress` or `logicalAddresses` |
+| params.CECAddresses.physicalAddress | array | The physical IP address of the device |
+| params.CECAddresses.physicalAddress[#] | string |  |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.1.cecAddressesChanged",
+    "params": {
+        "CECAddresses": {
+            "physicalAddress": [
+                "255, 255, 255, 255"
+            ]
+        }
+    }
+}
+```
+
+<a name="event.onMessage"></a>
+## *onMessage <sup>event</sup>*
+
+Triggered when a message is sent from an HDMI device.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.message | string | The message is a base64 encoded byte array of the raw CEC bytes. The CEC message includes the device ID for the intended destination |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.1.onMessage",
+    "params": {
+        "message": "1234567890"
+    }
+}
+```
+


### PR DESCRIPTION
This changeset copies the original org.rdk.HdmiCec plugin to a separate directory and adds the following methods:

enableOneTouchView,
triggerAction,
setCecPingInterval,
getConnectedDevices,
setName,
setOneTouchViewPolicy.
Additionally, the following event is added:

onDevicesChanged.
It has been observed that deactivating the plugin without disabling it first (calling the setEnabled method with "false") caused WPE Framework to crash. As a solution, the plugin Deinitialize() functions for both the original and new plugins now try to disable the respective plugin.