### PR TITLE
ONEMPERS-139 integrating LgiHdcpProfile Thunder plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,6 +311,10 @@ if(PLUGIN_FIREBOLTMEDIAPLAYER)
     add_subdirectory(FireboltMediaPlayer)
 endif()
 
+if(PLUGIN_LGIHDCPPROFILE)
+    add_subdirectory(LgiHdcpProfile)
+endif()
+
 if(WPEFRAMEWORK_CREATE_IPKG_TARGETS)
     set(CPACK_GENERATOR "DEB")
     set(CPACK_DEB_COMPONENT_INSTALL ON)

--- a/LgiHdcpProfile/CMakeLists.txt
+++ b/LgiHdcpProfile/CMakeLists.txt
@@ -1,0 +1,56 @@
+# If not stated otherwise in this file or this component's license file the
+# following copyright and licenses apply:
+#
+# Copyright 2020 RDK Management
+# Copyright 2021 Liberty Global Service B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(PLUGIN_NAME LgiHdcpProfile)
+set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
+
+find_package(${NAMESPACE}Plugins REQUIRED)
+
+add_library(${MODULE_NAME} SHARED
+        LgiHdcpProfile.cpp
+        ../HdcpProfile/HdcpProfile.cpp
+        Module.cpp
+        ../helpers/utils.cpp)
+
+add_definitions(-DMODULE_NAME=${PLUGIN_NAME})
+
+find_package(CURL)
+if (CURL_FOUND)
+        include_directories(${CURL_INCLUDE_DIRS})
+        target_link_libraries(${MODULE_NAME} PRIVATE ${CURL_LIBRARIES})
+else (CURL_FOUND)
+        message ("Curl/libcurl required.")
+endif (CURL_FOUND)
+
+set_target_properties(${MODULE_NAME} PROPERTIES
+        CXX_STANDARD 11
+        CXX_STANDARD_REQUIRED YES)
+
+find_package(DS)
+find_package(IARMBus)
+
+target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS} ../helpers ../HdcpProfile)
+target_include_directories(${MODULE_NAME} PRIVATE ${DS_INCLUDE_DIRS})
+
+target_link_libraries(${MODULE_NAME} PUBLIC ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES} ${DS_LIBRARIES} ${NAMESPACE}SecurityUtil)
+
+
+install(TARGETS ${MODULE_NAME}
+        DESTINATION lib/${STORAGE_DIRECTORY}/plugins)
+
+write_config(${PLUGIN_NAME})

--- a/LgiHdcpProfile/LgiHdcpProfile.config
+++ b/LgiHdcpProfile/LgiHdcpProfile.config
@@ -1,0 +1,11 @@
+set (autostart ${PLUGIN_LGIHDCPPROFILE_AUTOSTART})
+set (preconditions Platform)
+set (callsign "com.lgi.rdk.HdcpProfile")
+map()
+    key(root)
+    map()
+      kv(outofprocess ${PLUGIN_LGIHDCPPROFILE_OUTOFPROCESS})
+    end()
+end()
+
+ans(configuration)

--- a/LgiHdcpProfile/LgiHdcpProfile.cpp
+++ b/LgiHdcpProfile/LgiHdcpProfile.cpp
@@ -1,0 +1,116 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2019 RDK Management
+* Copyright 2021 Liberty Global Service B.V.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#include <string>
+
+#include "LgiHdcpProfile.h"
+
+#include "videoOutputPort.hpp"
+#include "videoOutputPortConfig.hpp"
+#include "dsMgr.h"
+#include "manager.hpp"
+#include "host.hpp"
+
+#include "utils.h"
+
+#define HDCP_PROFILE_METHOD_GET_Rx_HDCP_SUPPORT "getRxHDCPSupportedVersion"
+
+namespace WPEFramework
+{
+    namespace Plugin
+    {
+        SERVICE_REGISTRATION(LgiHdcpProfile, 1, 0);
+        static const char* getHdcpReasonStr (int eHDCPEnabledStatus);
+
+        LgiHdcpProfile::LgiHdcpProfile()
+        : HdcpProfile()
+        {
+            registerMethod(HDCP_PROFILE_METHOD_GET_Rx_HDCP_SUPPORT, &LgiHdcpProfile::getRxHDCPSupportedVersion, this);
+        }
+
+        LgiHdcpProfile::~LgiHdcpProfile()
+        {
+        }
+
+        //Begin methods
+        uint32_t LgiHdcpProfile::getRxHDCPSupportedVersion(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFO();
+
+            string rxHDCPSupportedVersion;
+            bool res = false;
+            bool isConnected = false;
+            dsHdcpProtocolVersion_t HDCPVersion = dsHDCP_VERSION_1X;
+            const string videoPort = parameters.HasLabel("videoPort") ? parameters["videoPort"].String() : "HDMI0";
+
+            try
+            {
+                device::VideoOutputPort vPort = device::VideoOutputPortConfig::getInstance().getPort(videoPort);
+                isConnected = vPort.isDisplayConnected();
+                if(isConnected)
+                {
+                    isConnected = vPort.isActive();
+                    if(isConnected)
+                    {
+                        HDCPVersion = (dsHdcpProtocolVersion_t)vPort.getRxHDCPSupportedVersion();
+                    }
+                }
+            }
+            catch (const std::exception e)
+            {
+                LOGWARN("DS exception caught: %s\n",e.what());
+                isConnected = false;
+            }
+
+            if(!isConnected)
+            {
+                rxHDCPSupportedVersion = "0.0";
+                LOGWARN("HDMI not connected; HDCP version unknown\n");
+            }
+            else
+            {
+                LOGINFO("HDMI connected, HDCP version %d\n",int(HDCPVersion));
+                switch(HDCPVersion)
+                {
+                    case dsHDCP_VERSION_2X:
+                        rxHDCPSupportedVersion = "2.2";
+                        res = true;
+                        break;
+                    case dsHDCP_VERSION_1X:
+                        res = true;
+                        rxHDCPSupportedVersion = "1.4";
+                        break;
+                    default:
+                        LOGWARN("protocol version value '%d' unknown; returning 0.0\n", HDCPVersion);
+                        rxHDCPSupportedVersion = "0.0";
+                        break;
+                }
+            }
+
+            response["supportedRxHDCPVersion"] = rxHDCPSupportedVersion;
+            returnResponse(res);
+        }
+
+        //End methods
+
+
+    } // namespace Plugin
+} // namespace WPEFramework
+

--- a/LgiHdcpProfile/LgiHdcpProfile.h
+++ b/LgiHdcpProfile/LgiHdcpProfile.h
@@ -1,0 +1,64 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2019 RDK Management
+* Copyright 2021 Liberty Global Service B.V.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#pragma once
+
+#include "Module.h"
+#include "HdcpProfile.h"
+
+#include "libIBus.h"
+
+#include "utils.h"
+
+namespace WPEFramework {
+
+    namespace Plugin {
+
+		// This is a server for a JSONRPC communication channel.
+		// For a plugin to be capable to handle JSONRPC, inherit from PluginHost::JSONRPC.
+		// By inheriting from this class, the plugin realizes the interface PluginHost::IDispatcher.
+		// This realization of this interface implements, by default, the following methods on this plugin
+		// - exists
+		// - register
+		// - unregister
+		// Any other methood to be handled by this plugin  can be added can be added by using the
+		// templated methods Register on the PluginHost::JSONRPC class.
+		// As the registration/unregistration of notifications is realized by the class PluginHost::JSONRPC,
+		// this class exposes a public method called, Notify(), using this methods, all subscribed clients
+		// will receive a JSONRPC message as a notification, in case this method is called.
+        class LgiHdcpProfile : public HdcpProfile {
+        private:
+
+            // We do not allow this plugin to be copied !!
+            LgiHdcpProfile(const LgiHdcpProfile&) = delete;
+            LgiHdcpProfile& operator=(const LgiHdcpProfile&) = delete;
+
+            //Begin methods
+            uint32_t getRxHDCPSupportedVersion(const JsonObject& parameters, JsonObject& response);
+
+            //End methods
+
+        public:
+            LgiHdcpProfile();
+            virtual ~LgiHdcpProfile();
+        };
+	} // namespace Plugin
+} // namespace WPEFramework
+

--- a/LgiHdcpProfile/LgiHdcpProfile.json
+++ b/LgiHdcpProfile/LgiHdcpProfile.json
@@ -1,0 +1,14 @@
+{
+ "locator":"libWPEFrameworkLgiHdcpProfile.so",
+ "classname":"LgiHdcpProfile",
+ "precondition":[
+  "Platform"
+ ],
+ "callsign":"com.lgi.rdk.HdcpProfile",
+ "autostart":false,
+ "configuration":{
+  "root":{
+   "outofprocess":true
+  }
+ }
+}

--- a/LgiHdcpProfile/LgiHdcpProfilePlugin.json
+++ b/LgiHdcpProfile/LgiHdcpProfilePlugin.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "../../Thunder/Tools/JsonGenerator/schemas/plugin.schema.json",
+    "info": {
+      "title": "HdcpProfile Plugin",
+      "callsign": "com.lgi.rdk.HdcpProfile",
+      "locator": "libWPEFrameworkLgiHdcpProfile.so",
+      "status": "production",
+      "description": "The HdcpProfile plugin provides an interface for HDCP-related data and events.",
+      "version": "1.0"
+    },
+    "interface": {
+      "$ref": "LgiHdcpProfile.json#"
+    }
+}

--- a/LgiHdcpProfile/Module.cpp
+++ b/LgiHdcpProfile/Module.cpp
@@ -1,0 +1,23 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2019 RDK Management
+* Copyright 2021 Liberty Global Service B.V.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#include "Module.h"
+
+MODULE_NAME_DECLARATION(BUILD_REFERENCE)

--- a/LgiHdcpProfile/Module.h
+++ b/LgiHdcpProfile/Module.h
@@ -1,0 +1,30 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2019 RDK Management
+* Copyright 2021 Liberty Global Service B.V.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#pragma once
+#ifndef MODULE_NAME
+#define MODULE_NAME LgiHdcpProfile
+#endif
+
+#include <plugins/plugins.h>
+#include <tracing/tracing.h>
+
+#undef EXTERNAL
+#define EXTERNAL

--- a/LgiHdcpProfile/README.md
+++ b/LgiHdcpProfile/README.md
@@ -1,0 +1,9 @@
+-----------------
+Build:
+
+bitbake wpeframework-service-plugins
+
+-----------------
+Test:
+
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0","id":"3","method": "com.lgi.rdk.HdcpProfile.1."}' http://127.0.0.1:9998/jsonrpc


### PR DESCRIPTION
And adding new plugin, LgiHdcpProfile - that extends org.rdk.HdcpProfile
and contains also Lgi addon methods; the callsign is com.lgi.rdk.HdcpProfile