### PR TITLE
fix compilation warnings when using LOGGER macros

### DIFF
--- a/helpers/utils.h
+++ b/helpers/utils.h
@@ -378,21 +378,21 @@ namespace Utils
 #endif
         };
 
-        static void sendMessage(char* message)
+        static void sendMessage(const char* message)
         {
 #ifdef ENABLE_TELEMETRY_LOGGING
             t2_event_s("THUNDER_MESSAGE", message);
 #endif
         };
 
-        static void sendMessage(char *marker, char* message)
+        static void sendMessage(const char *marker, const char* message)
         {
 #ifdef ENABLE_TELEMETRY_LOGGING
             t2_event_s(marker, message);
 #endif
         };
 
-        static void sendError(char* format, ...)
+        static void sendError(const char* format, ...)
         {
 #ifdef ENABLE_TELEMETRY_LOGGING
             va_list parameters;


### PR DESCRIPTION
this fixes compilation warnings like:

In file included from (...)/rdkservices/helpers/utils.cpp:27:0:
(...)/helpers/utils.cpp: In destructor 'Utils::ThreadRAII::~ThreadRAII()'
(...)/helpers/utils.h:48:241: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]

That come from LOGERR macros, defined here