### PR TITLE
[ONEM-15903] ODH reporting for OCDM - initialization retry

### DIFF
--- a/OpenCDMi/CMakeLists.txt
+++ b/OpenCDMi/CMakeLists.txt
@@ -57,6 +57,14 @@ else()
    target_link_libraries(${MODULE_NAME} PRIVATE ${PLUGINS_LIBRARIES} ${OCDM_LIBRARIES})
 endif()
 
+find_path(LIBODHERR_INCLUDE_DIR "rdk/libodherr/odherr.h")
+if (LIBODHERR_INCLUDE_DIR)
+  message(STATUS "ODH Error reporting support enabled (path: ${LIBODHERR_INCLUDE_DIR})")
+  target_compile_definitions(${MODULE_NAME} PRIVATE -DHAVE_LIBODHERR_ODHERR_H -DODH_SOURCE_NAME="OCDM")
+  target_include_directories(${MODULE_NAME} PRIVATE ${LIBODHERR_INCLUDE_DIR})
+  target_link_libraries(${MODULE_NAME} PRIVATE odherr jansson)
+endif(LIBODHERR_INCLUDE_DIR)
+
 # Library installation section
 string(TOLOWER ${NAMESPACE} STORAGENAME)
 install(TARGETS ${MODULE_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${STORAGENAME}/plugins)

--- a/OpenCDMi/FrameworkRPC.cpp
+++ b/OpenCDMi/FrameworkRPC.cpp
@@ -34,6 +34,8 @@
 #define INITIALIZATION_RETRY_SLEEP_MS         100         // delay in [ms] after getting CDMi_BUSY_CANNOT_INITIALIZE and retry
 #define INITIALIZATION_MAX_RETRY_COUNTER      50          // number of repetitions in retrying procedure
 
+#include "ReportErrors.h"
+
 extern "C" {
 
 typedef ::CDMi::ISystemFactory* (*GetDRMSystemFunction)();
@@ -755,6 +757,7 @@ namespace Plugin {
                             {
                                 TRACE(Trace::Warning, (_T("DRM initialization: success after re-trying, send SUCCESS notification")));
                                 _parent.initializationStatusNotify(keySystem, Exchange::IContentDecryption::Status::SUCCESS);
+                                ODH_ERROR_REPORT_CTX_ERROR(0, "DRM initialization: success after retrying", i);
                             }
                             if (sessionInterface != nullptr)
                             {
@@ -809,6 +812,7 @@ namespace Plugin {
                      {
                         TRACE(Trace::Error, (_T("DRM initialization: failed, send FAILED notification")));
                         _parent.initializationStatusNotify(keySystem, Exchange::IContentDecryption::Status::FAILED);
+                        ODH_ERROR_REPORT_CTX_ERROR(0, "DRM initialization: failed after retrying", INITIALIZATION_MAX_RETRY_COUNTER);
                      }
                  }
 

--- a/helpers/ReportErrors.h
+++ b/helpers/ReportErrors.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#ifdef HAVE_LIBODHERR_ODHERR_H
+
+#include <rdk/libodherr/odherr.hpp>
+
+#else
+
+#define ODH_ERROR_REPORT_CTX_ERROR(e, msg, ...)
+#define ODH_ERROR_REPORT_CTX_WARN(e, msg, ...)
+#define ODH_ERROR_REPORT_CTX_CRITICAL(e, msg, ...)
+#define ODH_ERROR_REPORT_ERROR_FORMAT_MSG(e, format, ...)
+#define ODH_ERROR_REPORT_WARN_FORMAT_MSG(e, format, ...)
+#define ODH_ERROR_REPORT_CRITICAL_FORMAT_MSG(e, format, ...)
+#define ODH_ERROR_REPORT_DEINIT()
+
+#endif


### PR DESCRIPTION
Part provided here is for OCDM errors in initialization retrying flow (while creating a new session)
All compiled and validated together here: https://gerrit.onemw.net/c/meta-lgi-om-common/+/87319
Example validation build: https://jenkins.onemw.net/job/EngineeringBuild/8146/