### PR TITLE
ONEMPERS-206 XCast: /app/system support

### DIFF
--- a/XCast/CMakeLists.txt
+++ b/XCast/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(${MODULE_NAME} SHARED
         XCast.cpp
         Module.cpp
         RtXcastConnector.cpp
+        XCastSystemRemoteObject.cpp
 	../helpers/tptimer.cpp
         ../helpers/utils.cpp)
 

--- a/XCast/RtNotifier.h
+++ b/XCast/RtNotifier.h
@@ -35,6 +35,8 @@ public:
             virtual void onXcastApplicationHideRequest(string appName, string appID)=0;
             virtual void onXcastApplicationResumeRequest(string appName, string appID)=0;
             virtual void onXcastApplicationStateRequest(string appName, string appID)=0;
+
+            virtual bool onXcastSystemApplicationSleepRequest(string key) = 0;
 };
 #endif
 

--- a/XCast/RtXcastConnector.cpp
+++ b/XCast/RtXcastConnector.cpp
@@ -168,6 +168,7 @@ rtError RtXcastConnector::onApplicationStateRequestCallback(int numArgs, const r
     
     return RT_OK;
 }
+
 /**
  * Callback function for application resume request from an app
  */
@@ -223,7 +224,8 @@ int RtXcastConnector::connectToRemoteService()
     const char * serviceName = "com.comcast.xdialcast";
     
     LOGINFO("connectToRemoteService entry " );
-    err = rtRemoteLocateObject(rtEnvironmentGetGlobal(), serviceName, xdialCastObj, NULL, &RtXcastConnector::remoteDisconnectCallback, m_observer);
+    const int timeout = 0;
+    err = rtRemoteLocateObject(rtEnvironmentGetGlobal(), serviceName, xdialCastObj, timeout, &RtXcastConnector::remoteDisconnectCallback, m_observer);
     if(err == RT_OK && xdialCastObj != NULL)
     {
         rtError e = xdialCastObj.send("on", "onApplicationLaunchRequest" , new rtFunctionCallback(RtXcastConnector::onApplicationLaunchRequestCallback, m_observer));
@@ -264,10 +266,16 @@ bool RtXcastConnector::initialize()
         m_runEventThread = true;
         m_eventMtrThread = std::thread(threadRun, this);
     }
+
+    m_xcast_system_remote_object->registerRemoteObject(env);
     return (err == RT_OK) ? true:false;
 }
 void RtXcastConnector::shutdown()
 {
+    m_xcast_system_remote_object->unregisterRemoteObject(rtEnvironmentGetGlobal());
+
+    rtRemoteShutdown(rtEnvironmentGetGlobal());
+
     LOGINFO("Shutting down rtRemote connectivity");
     {
         lock_guard<mutex> lock(m_threadlock);
@@ -276,7 +284,6 @@ void RtXcastConnector::shutdown()
     if (m_eventMtrThread.joinable())
         m_eventMtrThread.join();    
 
-    rtRemoteShutdown(rtEnvironmentGetGlobal());
     if(RtXcastConnector::_instance != nullptr)
     {
         delete RtXcastConnector::_instance;

--- a/XCast/RtXcastConnector.h
+++ b/XCast/RtXcastConnector.h
@@ -26,6 +26,9 @@
 #include <rtObject.h>
 #include <rtError.h>
 #include "RtNotifier.h"
+
+#include "XCastSystemRemoteObject.h"
+
 using namespace std;
 
 typedef struct _RegAppLaunchParams {
@@ -86,6 +89,7 @@ public:
     
     void setService(RtNotifier * service){
         m_observer = service;
+        m_xcast_system_remote_object->setService(service);
     }
 private:
     //Internal methods
@@ -97,6 +101,9 @@ private:
     mutex m_threadlock;
     // Boolean event thread exit condition
     bool m_runEventThread;
+
+    XCastSystemRemoteObjectReferenceWrapper m_xcast_system_remote_object;
+
     // Member function to handle RT messages.
     void processRtMessages();
     void clearAppLaunchParamList ();

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -650,5 +650,17 @@ bool XCast::checkRFCServiceStatus()
     return XCast::isCastEnabled;
 }
 
+bool XCast::onXcastSystemApplicationSleepRequest(string key)
+{
+    LOGINFO("onXcastSystemApplicationSleepRequest: key='%s'",key.c_str());
+    /*
+        this method needs to:
+            - check if the key is correct
+            - start transition to low power mode
+            - return true if the transition was successfully started, false otherwise
+    */
+    return true;
+}
+
 } // namespace Plugin
 } // namespace WPEFramework

--- a/XCast/XCast.h
+++ b/XCast/XCast.h
@@ -86,6 +86,8 @@ public:
     virtual void onXcastApplicationHideRequest(string appName, string appID) override;
     virtual void onXcastApplicationResumeRequest(string appName, string appID) override;
     virtual void onXcastApplicationStateRequest(string appName, string appID) override;
+    bool onXcastSystemApplicationSleepRequest(string key) override;
+
 private:
     /**
      * Whether Cast service is enabled by RFC

--- a/XCast/XCastSystemRemoteObject.cpp
+++ b/XCast/XCastSystemRemoteObject.cpp
@@ -1,0 +1,60 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2019 RDK Management
+* Copyright 2021 Liberty Global Service B.V.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#include "XCastSystemRemoteObject.h"
+
+#include "utils.h"
+
+using namespace WPEFramework;
+
+rtDefineMethod(XCastSystemRemoteObject, systemRequest);
+
+rtDefineObject(XCastSystemRemoteObject, rtObject);
+
+void XCastSystemRemoteObject::registerRemoteObject(rtRemoteEnvironment* env) {
+    rtRemoteRegisterObject(env, XCAST_SYSTEM_OBJECT_SERVICE_NAME, this);
+}
+
+void XCastSystemRemoteObject::setService(RtNotifier * service){
+    m_observer = service;
+}
+
+rtError XCastSystemRemoteObject::systemRequest(const rtObjectRef &params) {
+
+    if (!m_observer) {
+        LOGERR("XCastSystemRemoteObject::systemRequest init faiure\n");
+        return RT_FAIL;
+    }
+
+    rtError ret = RT_ERROR_INVALID_ARG;
+    const std::string action { params.get<rtString>("action")};
+
+    if ("sleep" == action) {
+        const std::string key {params.get<rtString>("key")};
+        const bool succeeded = m_observer->onXcastSystemApplicationSleepRequest(key);
+        return succeeded ? RT_OK : RT_FAIL;
+    }
+
+    return ret;
+}
+
+void XCastSystemRemoteObject::unregisterRemoteObject(rtRemoteEnvironment* env) {
+    rtRemoteUnregisterObject(env, XCAST_SYSTEM_OBJECT_SERVICE_NAME);
+}

--- a/XCast/XCastSystemRemoteObject.h
+++ b/XCast/XCastSystemRemoteObject.h
@@ -1,0 +1,68 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2019 RDK Management
+* Copyright 2021 Liberty Global Service B.V.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#pragma once
+
+#include <rtRemote.h>
+#include <rtObject.h>
+#include <rtError.h>
+#include "RtNotifier.h"
+
+#define XCAST_SYSTEM_OBJECT_SERVICE_NAME "com.comcast.xcast_system"
+
+class XCastSystemRemoteObject : public rtObject {
+
+    public:
+        XCastSystemRemoteObject() {
+        }
+        ~XCastSystemRemoteObject() {
+        }
+        XCastSystemRemoteObject(const XCastSystemRemoteObject&) = delete;
+        void operator=(const XCastSystemRemoteObject&) = delete;
+        rtDeclareObject(XCastSystemRemoteObject, rtObject);
+        rtMethod1ArgAndNoReturn("systemRequest", systemRequest, rtObjectRef);
+
+        void registerRemoteObject(rtRemoteEnvironment* env);
+        void setService(RtNotifier * service);
+        rtError systemRequest(const rtObjectRef &params);
+        void unregisterRemoteObject(rtRemoteEnvironment* env);
+
+    private:
+        RtNotifier * m_observer;
+};
+
+class XCastSystemRemoteObjectReferenceWrapper {
+public:
+    XCastSystemRemoteObject *obj;
+    XCastSystemRemoteObjectReferenceWrapper() : obj(new XCastSystemRemoteObject) {
+        obj->AddRef();
+    }
+    ~XCastSystemRemoteObjectReferenceWrapper() {
+        obj->Release();
+        obj = nullptr;
+    }
+
+    XCastSystemRemoteObjectReferenceWrapper(const XCastSystemRemoteObjectReferenceWrapper&) = delete;
+    void operator=(const XCastSystemRemoteObjectReferenceWrapper&) = delete;
+
+    XCastSystemRemoteObject* operator->() {
+        return obj;
+    }
+};


### PR DESCRIPTION
XCast support for system application request
introduced in DIAL 2.2 specs - 'sleep' method
this is only adding all the wiring necessary,
XCast::onXcastSystemApplicationSleepRequest is
still to be implemented.