### PR TITLE
ONEM-23137: Remove redundant inclusion of interfaces/definitions.h

### DIFF
--- a/TraceControl/Module.h
+++ b/TraceControl/Module.h
@@ -25,7 +25,6 @@
 #endif
 
 #include <plugins/plugins.h>
-#include <interfaces/definitions.h>
 
 #undef EXTERNAL
 #define EXTERNAL


### PR DESCRIPTION
From: Adam Stolcenburg <astolcenburg.contractor@libertyglobal.com>
Date: Tue, 9 Nov 2021 12:11:43 +0100

Header file interfaces/definitions.h includes the following headers
that are not always available:
- interfaces/IComposition.h
- interfaces/IStream.h
- interfaces/IVoiceHandler.h
- interfaces/IPower.h