### PR TITLE
[ONEM-24034] OCDM connector reconfigured

### DIFF
--- a/OpenCDMi/OCDM.config
+++ b/OpenCDMi/OCDM.config
@@ -33,6 +33,7 @@ ans(rootobject)
 
 map()
    kv(sharepath "/tmp/OCDM")
+   kv(connector "/tmp/OCDM/ocdm")
    kv(systems ___array___)
    if (NOT PLUGIN_OPENCDMI_MODE)
        kv(outofprocess ${PLUGIN_OPENCDMI_OOP})


### PR DESCRIPTION
default /tmp/ocdm changed to /tmp/OCDM/ocdm