### PR TITLE
ARRISAPOL-2345 lgi HdmiCec getConnectedDevices retval

### DIFF
--- a/LgiHdmiCec/LgiHdmiCec.cpp
+++ b/LgiHdmiCec/LgiHdmiCec.cpp
@@ -476,7 +476,7 @@ namespace WPEFramework
             sendNotify(HDMICEC_EVENT_ON_DEVICES_CHANGED, parameters);
         }
 
-        void LgiHdmiCec::getConnectedDevices(JsonArray &deviceList)
+        bool LgiHdmiCec::getConnectedDevices(JsonArray &deviceList)
         {
             LOGINFO();
             bool connected = false;
@@ -493,8 +493,7 @@ namespace WPEFramework
             if (!connected)
             {
                 LOGINFO("HDMI disconnected - empty devices list");
-
-                return;
+                return false;
             }
 
             try
@@ -520,7 +519,9 @@ namespace WPEFramework
             catch (const std::exception& e)
             {
                 LOGWARN("failed: %s", e.what());
+                return false;
             }
+            return true;
         }
 
         uint32_t LgiHdmiCec::getConnectedDevicesWrapper(const JsonObject& parameters, JsonObject& response)
@@ -529,9 +530,11 @@ namespace WPEFramework
 
             JsonArray deviceList;
 
+            bool retval = false;
+
             if(cecEnableStatus == true)
             {
-                getConnectedDevices(deviceList);
+                retval = getConnectedDevices(deviceList);
                 // force sending onDeviceChanged event on next scan end
                 m_updated = (m_updated || (deviceList.IsNull() && m_rescan_in_progress));
             }
@@ -542,7 +545,7 @@ namespace WPEFramework
             response["devices"] = deviceList;
             response["systemAudioMode"] = static_cast<bool>(m_system_audio_mode);
 
-            returnResponse(deviceList.IsSet() || (m_rescan_in_progress == false));
+            returnResponse(retval);
         }
 
         uint32_t LgiHdmiCec::setNameWrapper(const JsonObject& parameters, JsonObject& response)

--- a/LgiHdmiCec/LgiHdmiCec.h
+++ b/LgiHdmiCec/LgiHdmiCec.h
@@ -100,7 +100,7 @@ namespace WPEFramework {
             void onDevicesChanged();
             void onCecStatusChange(IARM_EventId_t eventId, const void* data_ptr, size_t len);
 
-            void getConnectedDevices(JsonArray &deviceList);
+            bool getConnectedDevices(JsonArray &deviceList);
 
             bool setChangedDeviceOsdName(const char* name, int logical_address);
             bool setChangedDeviceVendorId(uint32_t vendor_id, int logical_address);


### PR DESCRIPTION
return value changed to 'true' for the case when
returned list is empty, but no error occured
(most likely, the case when the scanning is still
in progress)