### PR TITLE
ARRISAPOL-2345 lgi HdmiCec getConnectedDevices retval

### DIFF
--- a/LgiHdmiCec/LgiHdmiCec.h
+++ b/LgiHdmiCec/LgiHdmiCec.h
@@ -100,7 +100,7 @@ namespace WPEFramework {
             void onDevicesChanged();
             void onCecStatusChange(IARM_EventId_t eventId, const void* data_ptr, size_t len);
 
-            void getConnectedDevices(JsonArray &deviceList);
+            bool getConnectedDevices(JsonArray &deviceList);
 
             bool setChangedDeviceOsdName(const char* name, int logical_address);
             bool setChangedDeviceVendorId(uint32_t vendor_id, int logical_address);


### PR DESCRIPTION
return value changed to 'true' for the case when
returned list is empty, but no error occured
(most likely, the case when the scanning is still
in progress). Also, when Cec is disabled, getConnectedDevices
shouldn't return failure (just empty list)