### PR TITLE
ONEMPERS-362 send friendlyname using dedicated handler

### DIFF
--- a/XCast/RtXcastConnector.cpp
+++ b/XCast/RtXcastConnector.cpp
@@ -309,20 +309,37 @@ int RtXcastConnector::applicationStateChanged( string app, string state, string 
         LOGINFO(" xdialCastObj is NULL ");
     return status;
 }//app && state not empty
-void RtXcastConnector::enableCastService(string friendlyname,bool enableService)
+
+void RtXcastConnector::enableCastService(bool enableService)
 {
-    LOGINFO("XcastService::enableCastService ARGS = %s : %d ", friendlyname.c_str(), enableService);
+    LOGINFO("XcastService::enableCastService ARGS = %d ", enableService);
     if(xdialCastObj != NULL)
     {
         rtObjectRef e = new rtMapObject;
         e.set("activation",(enableService ? "true": "false"));
-        e.set("friendlyname",friendlyname.c_str());
         int ret = xdialCastObj.send("onActivationChanged", e);
         LOGINFO("XcastService send onActivationChanged:%d",ret);
     }
     else
+    {
         LOGINFO(" xdialCastObj is NULL ");
-    
+    }
+}
+
+void RtXcastConnector::setFriendlyName(string friendlyname)
+{
+    LOGINFO("XcastService::setFriendlyName ARGS = %s", friendlyname.c_str());
+    if(xdialCastObj != NULL)
+    {
+        rtObjectRef e = new rtMapObject;
+        e.set("friendlyname", friendlyname.c_str());
+        int ret = xdialCastObj.send("onFriendlyNameChanged", e);
+        LOGINFO("XcastService send onFriendlyNameChanged:%d", ret);
+    }
+    else
+    {
+        LOGINFO("xdialCastObj is NULL ");
+    }
 }
 
 void RtXcastConnector::updateFriendlyName(string friendlyname)

--- a/XCast/RtXcastConnector.h
+++ b/XCast/RtXcastConnector.h
@@ -69,7 +69,14 @@ public:
      *@param friendlyname - friendlyname
      *@param enableService - Enable/Disable the SSDP discovery of Dial server
      */
-    void enableCastService(string friendlyname,bool enableService = true);
+    void enableCastService(bool enableService = true);
+
+    /**
+     *This function will set the device friendly name
+     *@param friendlyname - the new friendly name
+     */
+    void setFriendlyName(string friendlyname);
+
     /**
      *This function will update friendly name.
      *@param friendlyname - friendlyname

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -155,9 +155,9 @@ void XCast::powerModeChange(const char *owner, IARM_EventId_t eventId, void *dat
             if(m_standbyBehavior == false)
             {
                 if(m_xcastEnable && ( m_powerState == IARM_BUS_PWRMGR_POWERSTATE_ON))
-                    _rtConnector->enableCastService(m_friendlyName,true);
+                    _rtConnector->enableCastService(true);
                 else
-                    _rtConnector->enableCastService(m_friendlyName,false);
+                    _rtConnector->enableCastService(false);
             }
          }
     }
@@ -188,7 +188,7 @@ const string XCast::Initialize(PluginHost::IShell* /* service */)
 void XCast::Deinitialize(PluginHost::IShell* /* service */)
 {
     if( XCast::isCastEnabled){
-        _rtConnector->enableCastService(m_friendlyName,false);
+        _rtConnector->enableCastService(false);
         _rtConnector->shutdown();
     }
 }
@@ -250,9 +250,9 @@ uint32_t XCast::setEnabled(const JsonObject& parameters, JsonObject& response)
     }
     m_xcastEnable= enabled;
     if (m_xcastEnable && ( (m_standbyBehavior == true) || ((m_standbyBehavior == false)&&(m_powerState == IARM_BUS_PWRMGR_POWERSTATE_ON)) ) )
-        _rtConnector->enableCastService(m_friendlyName,true);
+        _rtConnector->enableCastService(true);
     else
-        _rtConnector->enableCastService(m_friendlyName,false);
+        _rtConnector->enableCastService(false);
     returnResponse(true);
 }
 uint32_t XCast::getEnabled(const JsonObject& parameters, JsonObject& response)
@@ -299,20 +299,17 @@ uint32_t XCast::setFriendlyName(const JsonObject& parameters, JsonObject& respon
     std::string paramStr;
     if (parameters.HasLabel("friendlyname"))
     {
-         getStringParameter("friendlyname",paramStr);
-         if(_rtConnector)
-         {
+        getStringParameter("friendlyname", paramStr);
+        if(_rtConnector)
+        {
             m_friendlyName = paramStr;
-            LOGINFO("XcastService::setFriendlyName  :%s",m_friendlyName.c_str());
-            if (m_xcastEnable && ( (m_standbyBehavior == true) || ((m_standbyBehavior == false)&&(m_powerState == IARM_BUS_PWRMGR_POWERSTATE_ON)) ) ) {
-               _rtConnector->enableCastService(m_friendlyName,true);
-            }
-            else {
-                _rtConnector->enableCastService(m_friendlyName,false);
-            }
-         }
-         else
+            LOGINFO("XcastService::setFriendlyName  :%s", m_friendlyName.c_str());
+            _rtConnector->setFriendlyName(paramStr);
+        }
+        else
+        {
             returnResponse(false);
+        }
     }
     else
     {
@@ -339,7 +336,7 @@ uint32_t XCast::registerApplications(const JsonObject& parameters, JsonObject& r
 	       LOGINFO("%s:%d _rtConnector Not NULL", __FUNCTION__, __LINE__);
            if(_rtConnector->IsDynamicAppListEnabled()) {
                /*Disable cast service before registering Applications*/
-               _rtConnector->enableCastService(m_friendlyName,false);
+               _rtConnector->enableCastService(false);
 
                _rtConnector->registerApplications (parameters["applications"].String());
 
@@ -348,7 +345,7 @@ uint32_t XCast::registerApplications(const JsonObject& parameters, JsonObject& r
                /*Reenabling cast service after registering Applications*/
                if (m_xcastEnable && ( (m_standbyBehavior == true) || ((m_standbyBehavior == false)&&(m_powerState == IARM_BUS_PWRMGR_POWERSTATE_ON)) ) ) {
                    LOGINFO("Enable CastService  m_xcastEnable: %d m_standbyBehavior: %d m_powerState:%d", m_xcastEnable, m_standbyBehavior, m_powerState);
-                   _rtConnector->enableCastService(m_friendlyName,true);
+                   _rtConnector->enableCastService(true);
                }
                else {
                    LOGINFO("CastService not enabled m_xcastEnable: %d m_standbyBehavior: %d m_powerState:%d", m_xcastEnable, m_standbyBehavior, m_powerState);
@@ -415,10 +412,10 @@ void XCast::onLocateCastTimer()
         LOGINFO("XCast::onLocateCastTimer : strDyAppConfig: %s _rtConnector: %p", strDyAppConfig.c_str(), _rtConnector);
     }
     if (m_xcastEnable && ( (m_standbyBehavior == true) || ((m_standbyBehavior == false)&&(m_powerState == IARM_BUS_PWRMGR_POWERSTATE_ON)) ) ) {
-        _rtConnector->enableCastService(m_friendlyName,true);
+        _rtConnector->enableCastService(true);
     }
     else {
-        _rtConnector->enableCastService(m_friendlyName,false);
+        _rtConnector->enableCastService(false);
     }
     
     LOGINFO("XCast::onLocateCastTimer : Timer still active ? %d ",m_locateCastTimer.isActive());


### PR DESCRIPTION
Previous implementation pass friendly name as a second parameter of
enable/disable xdial method. This was not implemented at xdial side and
it did not make any sense to combine these two values.