### PR TITLE
[ARRISEOS-41562] Send ODH report when ThunderWebKitBrowser started

### DIFF
--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -839,8 +839,11 @@ static GSourceFuncs _handlerIntervention =
             ASSERT(implementation == nullptr);
 
             // Initialize ODH reporting for WebKitBrowser
-            if (odh_error_report_init("WebKitBrowser"))
+            if (odh_error_report_init("WebKitBrowser")) {
                 TRACE(Trace::Error, (_T("Failed to initialize ODH reporting")));
+            } else {
+                ODH_WARNING("ThunderWebKitBrowser started: %p", this);
+            }
 
             implementation = this;
             TRACE_L1("%p", this);


### PR DESCRIPTION
Send ODH report which identifies that ThunderWebKitBrowser was started.
This is done to distinguish which browser has started (legacy WPE or WPE 2.22).