### PR TITLE
ARRISAPOL-2505 clean devices list on disable

### DIFF
--- a/LgiHdmiCec/LgiHdmiCec.cpp
+++ b/LgiHdmiCec/LgiHdmiCec.cpp
@@ -150,15 +150,14 @@ namespace WPEFramework
             if (cecSettingEnabled)
             {
                 setEnabled(cecSettingEnabled);
+                m_scan_id++;
+                requestRescanning(m_scan_id);
             }
             else
             {
                 setEnabled(false);
                 Utils::persistJsonSettings (CEC_SETTING_ENABLED_FILE, CEC_SETTING_ENABLED, JsonValue(false));
             }
-
-            m_scan_id++;
-            requestRescanning(m_scan_id);
         }
 
         LgiHdmiCec::~LgiHdmiCec()
@@ -638,6 +637,7 @@ namespace WPEFramework
 
         void LgiHdmiCec::CECEnable(void)
         {
+            std::lock_guard<std::mutex> guard(m_mutex);
             LOGWARN("Entered CECEnable");
             if (cecEnableStatus)
             {
@@ -677,6 +677,7 @@ namespace WPEFramework
 
         void LgiHdmiCec::CECDisable(void)
         {
+            std::lock_guard<std::mutex> guard(m_mutex);
             LOGWARN("Entered CECDisable ");
 
             if(!cecEnableStatus)
@@ -684,6 +685,11 @@ namespace WPEFramework
                 LOGWARN("CEC Already Disabled ");
                 return;
             }
+
+            m_devices.clear();
+            m_scan_devices.clear();
+            m_rescan_in_progress = false;
+            m_scan_id = 0;
 
             if (smConnection != NULL)
             {
@@ -967,7 +973,7 @@ namespace WPEFramework
         void LgiHdmiCec::onDeviceStatusChanged(IARM_EventId_t eventId, const void* data_ptr, size_t len)
         {
             assert(data_ptr != NULL);
-            if (len < sizeof(IARM_Bus_CECHost_DeviceStatusChanged_EventData_t))
+            if (!cecEnableStatus || len < sizeof(IARM_Bus_CECHost_DeviceStatusChanged_EventData_t))
             {
                 return;
             }
@@ -1068,7 +1074,7 @@ namespace WPEFramework
                 return;
             }
 
-            if ((m_scan_id > 0) && (m_scan_id != eData->scanId))
+            if (m_scan_id != eData->scanId)
             {
                 LOGWARN("skipped on invalid scan_id %d(%d) scan finished %d", eData->scanId, m_scan_id.load(), eData->isScanFinished);
             }


### PR DESCRIPTION
There's some discrepancy - cec devices list is being cleared in case when cec is disabled elsewhere (the plugin gets IARM_BUS_CECHost_EVENT_CECSTATUSCHANGE in this case; see LgiHdmiCec::onCecStatusChange). We should do the same in case cec is disabled by plugin in CECDisable.
Also, adding locks over CECEnable/CECDisable - as it is now, they can be executed concurrently which gives inconsistent results.
Additionally, do not start scanning when cec is disabled on startup (this leads to errors, since LibCCEC is not even initialized yet)