### PR TITLE
ONEMPERS-411 synchronise API calls & IARM handlers

### DIFF
--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -25,7 +25,7 @@
 #include "utils.h"
 #include "dsTypes.h"
 #include "tptimer.h"
-#include "AbstractPlugin.h"
+#include "AbstractPluginWithApiAndIARMLock.h"
 #include "libIBus.h"
 #include "libIBusDaemon.h"
 #include "irMgr.h"
@@ -47,7 +47,7 @@ namespace WPEFramework {
 		// As the registration/unregistration of notifications is realized by the class PluginHost::JSONRPC,
 		// this class exposes a public method called, Notify(), using this methods, all subscribed clients
 		// will receive a JSONRPC message as a notification, in case this method is called.
-        class DisplaySettings : public AbstractPlugin {
+        class DisplaySettings : public AbstractPluginWithApiAndIARMLock<DisplaySettings> {
         private:
             typedef Core::JSON::String JString;
             typedef Core::JSON::ArrayType<JString> JStringArray;
@@ -206,10 +206,15 @@ namespace WPEFramework {
                 ARC_STATE_ARC_EXIT
             };
 
-            int m_currentArcRoutingState; 
+            int m_currentArcRoutingState;
+            std::mutex m_apiLock;
 
         public:
             static DisplaySettings* _instance;
+
+            static std::mutex& getApiLock() {
+                return _instance->m_apiLock;
+            }
 
         };
 	} // namespace Plugin

--- a/HdcpProfile/HdcpProfile.cpp
+++ b/HdcpProfile/HdcpProfile.cpp
@@ -49,7 +49,7 @@ namespace WPEFramework
         HdcpProfile* HdcpProfile::_instance = nullptr;
 
         HdcpProfile::HdcpProfile()
-        : AbstractPlugin()
+        : AbstractPluginWithApiAndIARMLock()
         {
             HdcpProfile::_instance = this;
 
@@ -76,8 +76,8 @@ namespace WPEFramework
             Utils::IARM::init();
 
             IARM_Result_t res;
-            IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG, dsHdmiEventHandler) );
-            IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDCP_STATUS, dsHdmiEventHandler) );
+            IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG, locked_iarm_handler<dsHdmiEventHandler>) );
+            IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDCP_STATUS, locked_iarm_handler<dsHdmiEventHandler>) );
         }
 
         void HdcpProfile::DeinitializeIARM()

--- a/HdcpProfile/HdcpProfile.h
+++ b/HdcpProfile/HdcpProfile.h
@@ -23,7 +23,7 @@
 
 #include "Module.h"
 #include "utils.h"
-#include "AbstractPlugin.h"
+#include "AbstractPluginWithApiAndIARMLock.h"
 
 namespace WPEFramework {
 
@@ -41,7 +41,7 @@ namespace WPEFramework {
 		// As the registration/unregistration of notifications is realized by the class PluginHost::JSONRPC,
 		// this class exposes a public method called, Notify(), using this methods, all subscribed clients
 		// will receive a JSONRPC message as a notification, in case this method is called.
-        class HdcpProfile : public AbstractPlugin {
+        class HdcpProfile : public AbstractPluginWithApiAndIARMLock<HdcpProfile> {
         private:
 
             // We do not allow this plugin to be copied !!
@@ -63,6 +63,8 @@ namespace WPEFramework {
             void logHdcpStatus (const char *trigger, const JsonObject& status);
             static void dsHdmiEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 
+            std::mutex m_apiLock;
+
         public:
             HdcpProfile();
             virtual ~HdcpProfile();
@@ -71,6 +73,10 @@ namespace WPEFramework {
             void terminate();
 
             static HdcpProfile* _instance;
+
+            static std::mutex& getApiLock() {
+                return _instance->m_apiLock;
+            }
         };
 	} // namespace Plugin
 } // namespace WPEFramework

--- a/LgiHdmiCec/LgiHdmiCec.cpp
+++ b/LgiHdmiCec/LgiHdmiCec.cpp
@@ -121,7 +121,7 @@ namespace WPEFramework
         static std::atomic<int> libcecInitStatus{0};
 
         LgiHdmiCec::LgiHdmiCec()
-        : AbstractPlugin(),
+        : AbstractPluginWithApiAndIARMLock(),
             cecSettingEnabled(false),cecEnableStatus(false),smConnection(nullptr),
             m_scan_id(0), m_updated(false), m_rescan_in_progress(true), m_system_audio_mode(false)
         {
@@ -178,12 +178,12 @@ namespace WPEFramework
             if (Utils::IARM::init())
             {
                 IARM_Result_t res;
-                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_DAEMON_INITIALIZED,cecMgrEventHandler) );
-                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_STATUS_UPDATED,cecMgrEventHandler) );
-                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG, dsHdmiEventHandler) );
-                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_CECHOST_NAME, IARM_BUS_CECHost_EVENT_DEVICESTATUSCHANGE, cecHostDeviceStatusChangedEventHandler) );
-                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_CECHOST_NAME, IARM_BUS_CECHost_EVENT_DEVICESTATUSUPDATEEND, cecHostDeviceStatusUpdateEndEventHandler) );
-                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_CECHOST_NAME, IARM_BUS_CECHost_EVENT_CECSTATUSCHANGE, cecHostCecStatusChange) );
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_DAEMON_INITIALIZED,locked_iarm_handler<cecMgrEventHandler>) );
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_STATUS_UPDATED,locked_iarm_handler<cecMgrEventHandler>) );
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG, locked_iarm_handler<dsHdmiEventHandler>) );
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_CECHOST_NAME, IARM_BUS_CECHost_EVENT_DEVICESTATUSCHANGE, locked_iarm_handler<cecHostDeviceStatusChangedEventHandler>) );
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_CECHOST_NAME, IARM_BUS_CECHost_EVENT_DEVICESTATUSUPDATEEND, locked_iarm_handler<cecHostDeviceStatusUpdateEndEventHandler>) );
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_CECHOST_NAME, IARM_BUS_CECHost_EVENT_CECSTATUSCHANGE, locked_iarm_handler<cecHostCecStatusChange>) );
             }
         }
 
@@ -642,7 +642,6 @@ namespace WPEFramework
 
         void LgiHdmiCec::CECEnable(void)
         {
-            std::lock_guard<std::mutex> guard(m_mutex);
             LOGWARN("Entered CECEnable");
             if (cecEnableStatus)
             {
@@ -682,7 +681,6 @@ namespace WPEFramework
 
         void LgiHdmiCec::CECDisable(void)
         {
-            std::lock_guard<std::mutex> guard(m_mutex);
             LOGWARN("Entered CECDisable ");
 
             if(!cecEnableStatus)

--- a/LgiHdmiCec/LgiHdmiCec.h
+++ b/LgiHdmiCec/LgiHdmiCec.h
@@ -33,7 +33,7 @@
 
 #include "Module.h"
 #include "utils.h"
-#include "AbstractPlugin.h"
+#include "AbstractPluginWithApiAndIARMLock.h"
 
 namespace WPEFramework {
 
@@ -51,7 +51,7 @@ namespace WPEFramework {
 		// As the registration/unregistration of notifications is realized by the class PluginHost::JSONRPC,
 		// this class exposes a public method called, Notify(), using this methods, all subscribed clients
 		// will receive a JSONRPC message as a notification, in case this method is called.
-        class LgiHdmiCec : public AbstractPlugin, public FrameListener {
+        class LgiHdmiCec : public AbstractPluginWithApiAndIARMLock<LgiHdmiCec>, public FrameListener {
         private:
 
             // We do not allow this plugin to be copied !!
@@ -146,6 +146,13 @@ namespace WPEFramework {
             m_devices_map_t m_devices;
             m_devices_map_t m_scan_devices;
             std::mutex m_mutex;
+
+            std::mutex m_apiLock;
+
+        public:
+            static std::mutex& getApiLock() {
+                return _instance->m_apiLock;
+            }
         };
     } // namespace Plugin
 } // namespace WPEFramework

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -81,7 +81,7 @@ string strDyAppConfig = "";
 
 IARM_Bus_PWRMgr_PowerState_t XCast::m_powerState = IARM_BUS_PWRMGR_POWERSTATE_STANDBY;
 
-XCast::XCast() : AbstractPlugin()
+XCast::XCast() : AbstractPluginWithApiAndIARMLock()
 , m_apiVersionNumber(1)
 {
     InitializeIARM();
@@ -111,7 +111,7 @@ const void XCast::InitializeIARM()
      if (Utils::IARM::init())
      {
          IARM_Result_t res;
-         IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_PWRMGR_NAME,IARM_BUS_PWRMGR_EVENT_MODECHANGED, powerModeChange) );
+         IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_PWRMGR_NAME,IARM_BUS_PWRMGR_EVENT_MODECHANGED, locked_iarm_handler<powerModeChange>) );
          IARM_Bus_PWRMgr_GetPowerState_Param_t param;
          res = IARM_Bus_Call(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_API_GetPowerState,
                 (void *)&param, sizeof(param));

--- a/XCast/XCast.h
+++ b/XCast/XCast.h
@@ -22,7 +22,7 @@
 #include "tptimer.h"
 #include "Module.h"
 #include "utils.h"
-#include "AbstractPlugin.h"
+#include "AbstractPluginWithApiAndIARMLock.h"
 #include "RtNotifier.h"
 #include "libIBus.h"
 #include "libIBusDaemon.h"
@@ -43,7 +43,7 @@ namespace Plugin {
 // As the registration/unregistration of notifications is realized by the class PluginHost::JSONRPC,
 // this class exposes a public method called, Notify(), using this methods, all subscribed clients
 // will receive a JSONRPC message as a notification, in case this method is called.
-class XCast : public AbstractPlugin, public RtNotifier {
+class XCast : public AbstractPluginWithApiAndIARMLock<XCast>, public RtNotifier {
 private:
     
     // We do not allow this plugin to be copied !!
@@ -87,6 +87,11 @@ public:
     virtual void onXcastApplicationResumeRequest(string appName, string appID) override;
     virtual void onXcastApplicationStateRequest(string appName, string appID) override;
     bool onXcastSystemApplicationSleepRequest(string key) override;
+
+    static std::mutex& getApiLock() {
+        static std::mutex apiLock;
+        return apiLock;
+    }
 
 private:
     /**

--- a/helpers/AbstractPluginWithApiAndIARMLock.h
+++ b/helpers/AbstractPluginWithApiAndIARMLock.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <mutex>
+#include <libIBus.h>
+#include <AbstractPluginWithApiLock.h>
+
+namespace WPEFramework {
+
+    namespace Plugin {
+
+        /*
+            extends AbstractPluginWithApiLock with locked_iarm_handler that can be used to synchronize iarm event handlers
+
+            Template parameter LOCK_HOLDER specifies the class with static getApiLock() member
+            that returns the std::mutex used.
+
+        */
+        template<class LOCK_HOLDER>
+        class AbstractPluginWithApiAndIARMLock : public AbstractPluginWithApiLock<LOCK_HOLDER> {
+        public:
+
+            AbstractPluginWithApiAndIARMLock(const uint8_t currVersion) : AbstractPluginWithApiLock<LOCK_HOLDER>(currVersion) {}
+            AbstractPluginWithApiAndIARMLock() : AbstractPluginWithApiLock<LOCK_HOLDER>() {}
+
+            /*
+                locked_iarm_handler template can be used like:
+
+                    IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_RX_SENSE, locked_iarm_handler<DisplResolutionHandler>)
+
+                to register mutex-protected version of given IARM handler. The mutex is obtained from LOCK_HOLDER::getApiLock, so
+                can be the same that AbstractPluginWithApiLock::registerMethod uses, which allows to synchronize between IARM handlers
+                and API methods invocations.
+
+                Note that if IARM_Bus_RemoveEventHandler is used to unregister specific handlers, this wrapper needs to be used again!
+                This is not necessary in case of IARM_Bus_UnRegisterEventHandler (this unregisters all handlers for given event)
+            */
+            template<IARM_EventHandler_t CALLBACK_FUNCTION>
+            static void locked_iarm_handler(const char *owner, IARM_EventId_t eventId, void *data, size_t len) {
+                std::lock_guard<std::mutex> lock(LOCK_HOLDER::getApiLock());
+                // we can't be in IARM handler thread & API request thread at the same time, so
+                // it's safe to use AbstractPluginWithApiLock's isThreadUsingLockedApi here
+                isThreadUsingLockedApi = true;
+                try {
+                    CALLBACK_FUNCTION(owner, eventId, data, len);
+                } catch (...) {
+                    isThreadUsingLockedApi = false;
+                    throw;
+                }
+                isThreadUsingLockedApi = false;
+            }
+        };
+    } // Plugin
+} // WPEFramework

--- a/helpers/AbstractPluginWithApiLock.h
+++ b/helpers/AbstractPluginWithApiLock.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <mutex>
+
+#include <AbstractPlugin.h>
+
+namespace WPEFramework {
+
+    namespace Plugin {
+
+        namespace {
+            // set when inside of getFunctionToCall wrapper or locked_iarm_handler
+            thread_local bool isThreadUsingLockedApi = false;
+        }
+        /*
+            When plugin extends this instead of AbstractPlugin all API method invocations will be mutex protected.
+            Template parameter LOCK_HOLDER specifies the class with static getApiLock() member
+            that returns the std::mutex used.
+        */
+        template<class LOCK_HOLDER>
+        class AbstractPluginWithApiLock : public AbstractPlugin {
+
+        public:
+
+            AbstractPluginWithApiLock(const uint8_t currVersion) : AbstractPlugin(currVersion) {}
+            AbstractPluginWithApiLock() : AbstractPlugin() {}
+
+        protected:
+
+            template <typename METHOD, typename REALOBJECT>
+            std::function<uint32_t(REALOBJECT*, const WPEFramework::Core::JSON::VariantContainer&, WPEFramework::Core::JSON::VariantContainer&)>
+            getFunctionToCall(const METHOD& method, REALOBJECT* objectPtr) {
+                return [method](REALOBJECT *obj, const WPEFramework::Core::JSON::VariantContainer& in, WPEFramework::Core::JSON::VariantContainer& out) -> uint32_t {
+                    isThreadUsingLockedApi = true;
+                    std::lock_guard<std::mutex> lock(LOCK_HOLDER::getApiLock());
+                    uint32_t ret;
+                    try {
+                        ret = (obj->*method)(in, out);
+                    } catch (...) {
+                        isThreadUsingLockedApi = false;
+                        throw;
+                    }
+                    isThreadUsingLockedApi = false;
+                    return ret;
+                };
+            }
+
+            /* we are hiding, not overriding, AbstractPlugin::registerMethod */
+            template <typename METHOD, typename REALOBJECT>
+            void registerMethod(const string& methodName, const METHOD& method, REALOBJECT* objectPtr)
+            {
+                WPEFramework::Plugin::AbstractPlugin::registerMethod(methodName, getFunctionToCall(method, objectPtr), objectPtr);
+            }
+
+            /* we are hiding, not overriding, AbstractPlugin::registerMethod */
+            template <typename METHOD, typename REALOBJECT>
+            void registerMethod(const string& methodName, const METHOD& method, REALOBJECT* objectPtr, const std::vector<uint8_t> versions)
+            {
+                WPEFramework::Plugin::AbstractPlugin::registerMethod(methodName, getFunctionToCall(method, objectPtr), objectPtr, versions);
+            }
+
+        public:
+            /*
+                This guard can unlock & re-lock api mutex to prevent deadlock possible when calling other plugins via Invoke
+                (could deadlock in case when that other plugin called Invoke on this plugin at the same time, or tried to call
+                this plugin recursively, from the Invoke'd call).
+            */
+            struct UnlockApiGuard {
+                UnlockApiGuard() {
+                    if (isThreadUsingLockedApi) {
+                        LOCK_HOLDER::getApiLock().unlock();
+                    }
+                }
+                ~UnlockApiGuard() {
+                    if (isThreadUsingLockedApi) {
+                        LOCK_HOLDER::getApiLock().lock();
+                    }
+                }
+            };
+        };
+
+    } // Plugin
+} // WPEFramework


### PR DESCRIPTION
Review of threading safety (ONEMPERS-397) shows that there are multiple places where rdk plugins state can
be concurrently accessed by parallel threads, without any locking. This PR adds 'apiLock' mutex per plugin,
that assures synchronisation (and serialization) of API method calls & IARM event handlers, to avoid concurrency issues.
Updated plugins are:
LgiDisplaySettings/DisplaySettings
LgiHdmiCec
LgiHdcpProfile/HdcpProfile
XCast