### PR TITLE
ONEM-25360 Revert loading libraries from services directory in WPEProcess

### DIFF
--- a/OpenCDMi/CMakeLists.txt
+++ b/OpenCDMi/CMakeLists.txt
@@ -17,23 +17,24 @@
 
 set(PLUGIN_NAME OCDM)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
+set(PLUGIN_OCDM_IMPLEMENTATION "${MODULE_NAME}Impl" CACHE STRING "Specify a library with a OCDM implementation." )
 
 find_package(ocdm REQUIRED)
 find_package(${NAMESPACE}Plugins REQUIRED)
 find_package(CompileSettingsDebug CONFIG REQUIRED)
 find_package(${NAMESPACE}Definitions REQUIRED)
 
-add_library(${MODULE_NAME} SHARED 
+add_library(${MODULE_NAME} SHARED
         OCDM.cpp
         OCDMJsonRpc.cpp
         Module.cpp)
 
-add_library(${MODULE_NAME}Service SHARED
+add_library(${PLUGIN_OCDM_IMPLEMENTATION} SHARED
         CENCParser.cpp
         FrameworkRPC.cpp
         Module.cpp)
 
-add_dependencies(${MODULE_NAME} ${MODULE_NAME}Service)
+add_dependencies(${MODULE_NAME} ${PLUGIN_OCDM_IMPLEMENTATION})
 
 # avoid -as-needed flag being set, this will break linking to libocdm.so
 string(REPLACE "-Wl,--as-needed" "" CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
@@ -43,29 +44,29 @@ set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES)
 
-set_target_properties(${MODULE_NAME}Service PROPERTIES
+set_target_properties(${PLUGIN_OCDM_IMPLEMENTATION} PROPERTIES
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES)
 
 target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
-target_include_directories(${MODULE_NAME}Service PRIVATE ../helpers)
-target_link_libraries(${MODULE_NAME} 
+target_include_directories(${PLUGIN_OCDM_IMPLEMENTATION} PRIVATE ../helpers)
+target_link_libraries(${MODULE_NAME}
         PRIVATE
                 CompileSettingsDebug::CompileSettingsDebug
-                ${NAMESPACE}Plugins::${NAMESPACE}Plugins 
+                ${NAMESPACE}Plugins::${NAMESPACE}Plugins
                 ${NAMESPACE}Definitions::${NAMESPACE}Definitions)
-target_link_libraries(${MODULE_NAME}Service
+target_link_libraries(${PLUGIN_OCDM_IMPLEMENTATION}
         PRIVATE
                 CompileSettingsDebug::CompileSettingsDebug
                 ${NAMESPACE}Plugins::${NAMESPACE}Plugins
                 ${NAMESPACE}Definitions::${NAMESPACE}Definitions
                 ocdm::ocdm)
 # Library definition section
-install(TARGETS ${MODULE_NAME} 
+install(TARGETS ${MODULE_NAME}
         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${STORAGE_DIRECTORY}/plugins)
 
-install(TARGETS ${MODULE_NAME}Service
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${STORAGE_DIRECTORY}/services)
+install(TARGETS ${PLUGIN_OCDM_IMPLEMENTATION}
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${STORAGE_DIRECTORY}/plugins)
 
 if("${CMAKE_FIND_ROOT_PATH}" STREQUAL "")
    # Desktop case: not cross compiling
@@ -78,9 +79,9 @@ endif()
 find_path(LIBODHERR_INCLUDE_DIR "rdk/libodherr/odherr.h")
 if (LIBODHERR_INCLUDE_DIR)
   message(STATUS "ODH Error reporting support enabled (path: ${LIBODHERR_INCLUDE_DIR})")
-  target_compile_definitions(${MODULE_NAME}Service PRIVATE -DHAVE_LIBODHERR_ODHERR_H -DODH_SOURCE_NAME="OCDM")
-  target_include_directories(${MODULE_NAME}Service PRIVATE ${LIBODHERR_INCLUDE_DIR})
-  target_link_libraries(${MODULE_NAME}Service PRIVATE odherr jansson)
+  target_compile_definitions(${PLUGIN_OCDM_IMPLEMENTATION} PRIVATE -DHAVE_LIBODHERR_ODHERR_H -DODH_SOURCE_NAME="OCDM")
+  target_include_directories(${PLUGIN_OCDM_IMPLEMENTATION} PRIVATE ${LIBODHERR_INCLUDE_DIR})
+  target_link_libraries(${PLUGIN_OCDM_IMPLEMENTATION} PRIVATE odherr jansson)
 endif(LIBODHERR_INCLUDE_DIR)
 
 # Library installation section

--- a/OpenCDMi/OCDM.config
+++ b/OpenCDMi/OCDM.config
@@ -7,6 +7,7 @@ set(preconditions ${preconditions} Platform)
 endif()
 
 map()
+    kv(locator lib${PLUGIN_OCDM_IMPLEMENTATION}.so)
     if(PLUGIN_OPENCDMI_MODE)
         kv(mode ${PLUGIN_OPENCDMI_MODE})
     else()


### PR DESCRIPTION
This commit partially reverts changes done in ONEM-24420
and the following pull request
https://github.com/LibertyGlobal/rdkservices/pull/109/

On top of that it implements the split according to the new approach
described here
https://wikiprojects.upc.biz/display/CTOM/Splitting+code+of+Thunder+micro+services

DEPS=meta-lgi-om-common:94525/2