### PR TITLE
ONEMPERS-411 synchronise API calls & IARM handlers

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -143,7 +143,7 @@ namespace WPEFramework {
         IARM_Bus_PWRMgr_PowerState_t DisplaySettings::m_powerState = IARM_BUS_PWRMGR_POWERSTATE_STANDBY;
 
         DisplaySettings::DisplaySettings()
-            : AbstractPlugin(2)
+            : AbstractPluginWithApiAndIARMLock(2)
         {
             LOGINFO("ctor");
             DisplaySettings::_instance = this;
@@ -3855,7 +3855,10 @@ namespace WPEFramework {
                     }
 
                     LOGINFO("ARC Routing - %d \n", arcEnable);
-                    hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "setupARCRouting", param, hdmiCecSinkResult);
+                    {
+                        UnlockApiGuard unlockApi;
+                        hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "setupARCRouting", param, hdmiCecSinkResult);
+                    }
                     if (!hdmiCecSinkResult["success"].Boolean()) {
 			success = false;
                         LOGERR("HdmiCecSink Plugin returned error\n");
@@ -3884,7 +3887,10 @@ namespace WPEFramework {
                     JsonObject hdmiCecSinkResult;
                     JsonObject param;
 
-                    hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "getEnabled", param, hdmiCecSinkResult);
+                    {
+                        UnlockApiGuard unlockApi;
+                        hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "getEnabled", param, hdmiCecSinkResult);
+                    }
 
 		    cecEnable = hdmiCecSinkResult["enabled"].Boolean();
 		    LOGINFO("get-cecEnabled [%d]\n",cecEnable);
@@ -3916,7 +3922,10 @@ namespace WPEFramework {
                     JsonObject hdmiCecSinkResult;
                     JsonObject param;
 
-                    hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "getAudioDeviceConnectedStatus", param, hdmiCecSinkResult);
+                    {
+                        UnlockApiGuard unlockApi;
+                        hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "getAudioDeviceConnectedStatus", param, hdmiCecSinkResult);
+                    }
 
                     hdmiAudioDeviceDetected = hdmiCecSinkResult["connected"].Boolean();
                     LOGINFO("getAudioDeviceConnectedStatus [%d]\n",hdmiAudioDeviceDetected);
@@ -3948,7 +3957,10 @@ namespace WPEFramework {
                     JsonObject param;
 
                     LOGINFO("%s: Send Audio Device Power On !!!\n");
-                    hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "sendAudioDevicePowerOnMessage", param, hdmiCecSinkResult);
+                    {
+                        UnlockApiGuard unlockApi;
+                        hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "sendAudioDevicePowerOnMessage", param, hdmiCecSinkResult);
+                    }
                     if (!hdmiCecSinkResult["success"].Boolean()) {
                         success = false;
                         LOGERR("HdmiCecSink Plugin returned error\n");
@@ -3977,7 +3989,10 @@ namespace WPEFramework {
                     JsonObject param;
 
                     LOGINFO("Requesting Short Audio Descriptor \n");
-                    hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "requestShortAudioDescriptor", param, hdmiCecSinkResult);
+                    {
+                        UnlockApiGuard unlockApi;
+                        hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "requestShortAudioDescriptor", param, hdmiCecSinkResult);
+                    }
                     if (!hdmiCecSinkResult["success"].Boolean()) {
                         success = false;
                         LOGERR("HdmiCecSink Plugin returned error\n");

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -25,7 +25,7 @@
 #include "utils.h"
 #include "dsTypes.h"
 #include "tptimer.h"
-#include "AbstractPlugin.h"
+#include "AbstractPluginWithApiAndIARMLock.h"
 #include "libIBus.h"
 #include "libIBusDaemon.h"
 #include "irMgr.h"
@@ -47,7 +47,7 @@ namespace WPEFramework {
 		// As the registration/unregistration of notifications is realized by the class PluginHost::JSONRPC,
 		// this class exposes a public method called, Notify(), using this methods, all subscribed clients
 		// will receive a JSONRPC message as a notification, in case this method is called.
-        class DisplaySettings : public AbstractPlugin {
+        class DisplaySettings : public AbstractPluginWithApiAndIARMLock {
         private:
             typedef Core::JSON::String JString;
             typedef Core::JSON::ArrayType<JString> JStringArray;

--- a/HdcpProfile/HdcpProfile.cpp
+++ b/HdcpProfile/HdcpProfile.cpp
@@ -48,7 +48,7 @@ namespace WPEFramework
         HdcpProfile* HdcpProfile::_instance = nullptr;
 
         HdcpProfile::HdcpProfile()
-        : AbstractPlugin()
+        : AbstractPluginWithApiAndIARMLock()
         {
             HdcpProfile::_instance = this;
 

--- a/HdcpProfile/HdcpProfile.h
+++ b/HdcpProfile/HdcpProfile.h
@@ -23,7 +23,7 @@
 
 #include "Module.h"
 #include "utils.h"
-#include "AbstractPlugin.h"
+#include "AbstractPluginWithApiAndIARMLock.h"
 
 namespace WPEFramework {
 
@@ -41,7 +41,7 @@ namespace WPEFramework {
 		// As the registration/unregistration of notifications is realized by the class PluginHost::JSONRPC,
 		// this class exposes a public method called, Notify(), using this methods, all subscribed clients
 		// will receive a JSONRPC message as a notification, in case this method is called.
-        class HdcpProfile : public AbstractPlugin {
+        class HdcpProfile : public AbstractPluginWithApiAndIARMLock {
         private:
 
             // We do not allow this plugin to be copied !!

--- a/LgiHdmiCec/LgiHdmiCec.cpp
+++ b/LgiHdmiCec/LgiHdmiCec.cpp
@@ -121,7 +121,7 @@ namespace WPEFramework
         static std::atomic<int> libcecInitStatus{0};
 
         LgiHdmiCec::LgiHdmiCec()
-        : AbstractPlugin(),
+        : AbstractPluginWithApiAndIARMLock(),
             cecSettingEnabled(false),cecEnableStatus(false),smConnection(nullptr),
             m_scan_id(0), m_updated(false), m_rescan_in_progress(true), m_system_audio_mode(false)
         {
@@ -642,7 +642,6 @@ namespace WPEFramework
 
         void LgiHdmiCec::CECEnable(void)
         {
-            std::lock_guard<std::mutex> guard(m_mutex);
             LOGWARN("Entered CECEnable");
             if (cecEnableStatus)
             {
@@ -682,7 +681,6 @@ namespace WPEFramework
 
         void LgiHdmiCec::CECDisable(void)
         {
-            std::lock_guard<std::mutex> guard(m_mutex);
             LOGWARN("Entered CECDisable ");
 
             if(!cecEnableStatus)

--- a/LgiHdmiCec/LgiHdmiCec.h
+++ b/LgiHdmiCec/LgiHdmiCec.h
@@ -33,7 +33,7 @@
 
 #include "Module.h"
 #include "utils.h"
-#include "AbstractPlugin.h"
+#include "AbstractPluginWithApiAndIARMLock.h"
 
 namespace WPEFramework {
 
@@ -51,7 +51,7 @@ namespace WPEFramework {
 		// As the registration/unregistration of notifications is realized by the class PluginHost::JSONRPC,
 		// this class exposes a public method called, Notify(), using this methods, all subscribed clients
 		// will receive a JSONRPC message as a notification, in case this method is called.
-        class LgiHdmiCec : public AbstractPlugin, public FrameListener {
+        class LgiHdmiCec : public AbstractPluginWithApiAndIARMLock, public FrameListener {
         private:
 
             // We do not allow this plugin to be copied !!

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -81,7 +81,7 @@ string strDyAppConfig = "";
 
 IARM_Bus_PWRMgr_PowerState_t XCast::m_powerState = IARM_BUS_PWRMGR_POWERSTATE_STANDBY;
 
-XCast::XCast() : AbstractPlugin()
+XCast::XCast() : AbstractPluginWithApiAndIARMLock()
 , m_apiVersionNumber(1)
 {
     InitializeIARM();

--- a/XCast/XCast.h
+++ b/XCast/XCast.h
@@ -22,7 +22,7 @@
 #include "tptimer.h"
 #include "Module.h"
 #include "utils.h"
-#include "AbstractPlugin.h"
+#include "AbstractPluginWithApiAndIARMLock.h"
 #include "RtNotifier.h"
 #include "libIBus.h"
 #include "libIBusDaemon.h"
@@ -43,7 +43,7 @@ namespace Plugin {
 // As the registration/unregistration of notifications is realized by the class PluginHost::JSONRPC,
 // this class exposes a public method called, Notify(), using this methods, all subscribed clients
 // will receive a JSONRPC message as a notification, in case this method is called.
-class XCast : public AbstractPlugin, public RtNotifier {
+class XCast : public AbstractPluginWithApiAndIARMLock, public RtNotifier {
 private:
     
     // We do not allow this plugin to be copied !!

--- a/helpers/AbstractPluginWithApiAndIARMLock.h
+++ b/helpers/AbstractPluginWithApiAndIARMLock.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <mutex>
+#include <libIBus.h>
+#include <AbstractPluginWithApiLock.h>
+#include <map>
+#include <string>
+
+namespace WPEFramework {
+
+    namespace Plugin {
+
+        static std::map<std::string, std::map<IARM_EventId_t, IARM_EventHandler_t>> _registered_iarm_handlers;
+
+        static void _generic_iarm_handler(const char *owner, IARM_EventId_t eventId, void *data, size_t len) {
+            std::lock_guard<std::mutex> lock(AbstractPluginWithApiLock::getApiLock());
+            // we can't be in IARM handler thread & API request thread at the same time, so
+            // it's safe to use AbstractPluginWithApiLock's isThreadUsingLockedApi here
+            isThreadUsingLockedApi = true;
+            try {
+                if (_registered_iarm_handlers[owner].count(eventId)) {
+                    _registered_iarm_handlers[owner][eventId](owner, eventId, data, len);
+                } else {
+                    LOGERR("missing handler for %s / %d", owner, eventId);
+                }
+            } catch (...) {
+                isThreadUsingLockedApi = false;
+                throw;
+            }
+            isThreadUsingLockedApi = false;
+        }
+        /*
+            provides overloaded versions of IARM_Bus_RegisterEventHandler (and IARM_Bus_UnRegisterEventHandler)
+            that take locks when executing
+        */
+        class AbstractPluginWithApiAndIARMLock : public AbstractPluginWithApiLock {
+        public:
+
+            AbstractPluginWithApiAndIARMLock(const uint8_t currVersion) : AbstractPluginWithApiLock(currVersion) {}
+            AbstractPluginWithApiAndIARMLock() : AbstractPluginWithApiLock() {}
+
+            // we are providing IARM_Bus_RegisterEventHandler as new static member (libiarm provides standalone function)
+            static IARM_Result_t IARM_Bus_RegisterEventHandler(const char *ownerName, IARM_EventId_t eventId, IARM_EventHandler_t handler) {
+                if (_registered_iarm_handlers[ownerName].count(eventId)) {
+                    LOGERR("double registration for %s / %d ; previous handler will be overriden", ownerName, eventId);
+                }
+                _registered_iarm_handlers[ownerName][eventId] = handler;
+                auto ret = ::IARM_Bus_RegisterEventHandler(ownerName, eventId, _generic_iarm_handler);
+                if (IARM_RESULT_SUCCESS != ret) {
+                    _registered_iarm_handlers[ownerName].erase(eventId);
+                }
+                return ret;
+            }
+
+            // we are providing IARM_Bus_UnRegisterEventHandler as new static member (libiarm provides standalone function)
+            static IARM_Result_t IARM_Bus_UnRegisterEventHandler(const char *ownerName, IARM_EventId_t eventId) {
+                _registered_iarm_handlers[ownerName].erase(eventId);
+                return ::IARM_Bus_UnRegisterEventHandler(ownerName, eventId);
+            }
+        };
+    } // Plugin
+} // WPEFramework

--- a/helpers/AbstractPluginWithApiLock.h
+++ b/helpers/AbstractPluginWithApiLock.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <mutex>
+
+#include <AbstractPlugin.h>
+
+namespace WPEFramework {
+
+    namespace Plugin {
+
+        namespace {
+            // set when inside of getFunctionToCall wrapper (or locked IARM handler - see AbstractPluginWithApiAndIARMLock)
+            thread_local bool isThreadUsingLockedApi = false;
+        }
+        /*
+            When plugin extends this instead of AbstractPlugin all API method invocations will be mutex protected.
+        */
+        class AbstractPluginWithApiLock : public AbstractPlugin {
+
+        public:
+
+            AbstractPluginWithApiLock(const uint8_t currVersion) : AbstractPlugin(currVersion) {}
+            AbstractPluginWithApiLock() : AbstractPlugin() {}
+
+        protected:
+
+            template <typename METHOD, typename REALOBJECT>
+            std::function<uint32_t(REALOBJECT*, const WPEFramework::Core::JSON::VariantContainer&, WPEFramework::Core::JSON::VariantContainer&)>
+            getFunctionToCall(const METHOD& method, REALOBJECT* objectPtr) {
+                return [method](REALOBJECT *obj, const WPEFramework::Core::JSON::VariantContainer& in, WPEFramework::Core::JSON::VariantContainer& out) -> uint32_t {
+                    isThreadUsingLockedApi = true;
+                    std::lock_guard<std::mutex> lock(getApiLock());
+                    uint32_t ret;
+                    try {
+                        ret = (obj->*method)(in, out);
+                    } catch (...) {
+                        isThreadUsingLockedApi = false;
+                        throw;
+                    }
+                    isThreadUsingLockedApi = false;
+                    return ret;
+                };
+            }
+
+            /* we are hiding, not overriding, AbstractPlugin::registerMethod */
+            template <typename METHOD, typename REALOBJECT>
+            void registerMethod(const string& methodName, const METHOD& method, REALOBJECT* objectPtr)
+            {
+                WPEFramework::Plugin::AbstractPlugin::registerMethod(methodName, getFunctionToCall(method, objectPtr), objectPtr);
+            }
+
+            /* we are hiding, not overriding, AbstractPlugin::registerMethod */
+            template <typename METHOD, typename REALOBJECT>
+            void registerMethod(const string& methodName, const METHOD& method, REALOBJECT* objectPtr, const std::vector<uint8_t> versions)
+            {
+                WPEFramework::Plugin::AbstractPlugin::registerMethod(methodName, getFunctionToCall(method, objectPtr), objectPtr, versions);
+            }
+
+        public:
+            /*
+                This guard can unlock & re-lock api mutex to prevent deadlock possible when calling other plugins via Invoke
+                (could deadlock in case when that other plugin called Invoke on this plugin at the same time, or tried to call
+                this plugin recursively, from the Invoke'd call).
+            */
+            struct UnlockApiGuard {
+                UnlockApiGuard() {
+                    if (isThreadUsingLockedApi) {
+                        getApiLock().unlock();
+                    }
+                }
+                ~UnlockApiGuard() {
+                    if (isThreadUsingLockedApi) {
+                        getApiLock().lock();
+                    }
+                }
+            };
+
+            static std::mutex& getApiLock() {
+                static std::mutex apiLock;
+                return apiLock;
+            }
+        };
+
+    } // Plugin
+} // WPEFramework


### PR DESCRIPTION
Review of threading safety (ONEMPERS-397) shows that
there are multiple places where rdk plugins state can
be concurrently accessed by parallel threads, without
any locking. This PR adds 'apiLock' mutex per plugin,
that assures synchronisation (and serialization) of
API method calls & IARM event handlers, to avoid
concurrency issues.
Updated plugins are:
LgiDisplaySettings/DisplaySettings
LgiHdmiCec
LgiHdcpProfile/HdcpProfile
XCast