### PR TITLE
ARRISAPOL-2697 do not clean scan id on another scan event

### DIFF
--- a/LgiHdmiCec/LgiHdmiCec.h
+++ b/LgiHdmiCec/LgiHdmiCec.h
@@ -74,6 +74,7 @@ namespace WPEFramework {
             LgiHdmiCec();
             virtual ~LgiHdmiCec();
             virtual void Deinitialize(PluginHost::IShell* service) override;
+            int getNextScanId();
 
         public:
             static LgiHdmiCec* _instance;


### PR DESCRIPTION
Seems that we can sometimes get notified about some other hdmi cec
scans that have finished, and in such case we were invalidating
scan id of the scan we are waiting for