### PR TITLE
[ARRISEOS-43099] Fix: NTP sync up breaks timer

### DIFF
--- a/WebKitBrowser/CMakeLists.txt
+++ b/WebKitBrowser/CMakeLists.txt
@@ -136,6 +136,7 @@ find_package(WPEWebKit REQUIRED)
 find_package(WPEBackend REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_library(ODHERR odherr)
+find_package(Threads REQUIRED)
 if(DEFINED WEBKIT_GLIB_API)
 find_package(LibSoup REQUIRED)
 endif()
@@ -197,6 +198,7 @@ target_link_libraries(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION}
         ${WPE_WEBKIT_LIBRARIES}
         ${OPENSSL_LIBRARIES}
         ${ODHERR}
+        Threads::Threads
 )
 
 if(WPE_WEBKIT_DEPRECATED_API)


### PR DESCRIPTION
After backporting full steady_clock support to condition_variable fails to build
webkitbrowser-plugin without pthread. Error message:
/usr/include/c++/9.3.0/condition_variable:201: error: undefined reference to
'pthread_cond_clockwait'
