### PR TITLE
porting onempers-411 changes

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -221,7 +221,7 @@ namespace WPEFramework {
         IARM_Bus_PWRMgr_PowerState_t DisplaySettings::m_powerState = IARM_BUS_PWRMGR_POWERSTATE_STANDBY;
 
         DisplaySettings::DisplaySettings()
-            : PluginHost::JSONRPC()
+            // : PluginHost::JSONRPC()
         {
             LOGINFO("ctor");
             DisplaySettings::_instance = this;
@@ -4022,7 +4022,10 @@ namespace WPEFramework {
                     }
 
                     LOGINFO("ARC Routing - %d \n", arcEnable);
-                    gHdmiCecConnection->Invoke<JsonObject, JsonObject>(2000, "setupARCRouting", param, hdmiCecSinkResult);
+                    {
+                        UnlockApiGuard unlockApi;
+                        gHdmiCecConnection->Invoke<JsonObject, JsonObject>(2000, "setupARCRouting", param, hdmiCecSinkResult);
+                    }
                     if (!hdmiCecSinkResult["success"].Boolean()) {
 			success = false;
                         LOGERR("HdmiCecSink Plugin returned error\n");
@@ -4053,7 +4056,10 @@ namespace WPEFramework {
                     JsonObject hdmiCecSinkResult;
                     JsonObject param;
 
-                    gHdmiCecConnection->Invoke<JsonObject, JsonObject>(2000, "getEnabled", param, hdmiCecSinkResult);
+                    {
+                        UnlockApiGuard unlockApi;
+                        gHdmiCecConnection->Invoke<JsonObject, JsonObject>(2000, "getEnabled", param, hdmiCecSinkResult);
+                    }
 
 		    cecEnable = hdmiCecSinkResult["enabled"].Boolean();
 		    LOGINFO("get-cecEnabled [%d]\n",cecEnable);
@@ -4085,7 +4091,10 @@ namespace WPEFramework {
                     JsonObject hdmiCecSinkResult;
                     JsonObject param;
 
-                    gHdmiCecConnection->Invoke<JsonObject, JsonObject>(2000, "getAudioDeviceConnectedStatus", param, hdmiCecSinkResult);
+                    {
+                        UnlockApiGuard unlockApi;
+                        gHdmiCecConnection->Invoke<JsonObject, JsonObject>(2000, "getAudioDeviceConnectedStatus", param, hdmiCecSinkResult);
+                    }
 
                     hdmiAudioDeviceDetected = hdmiCecSinkResult["connected"].Boolean();
                     LOGINFO("getAudioDeviceConnectedStatus [%d]\n",hdmiAudioDeviceDetected);
@@ -4118,7 +4127,10 @@ namespace WPEFramework {
                     JsonObject param;
 
                     LOGINFO("Send Audio Device Power On !!!\n");
-                    gHdmiCecConnection->Invoke<JsonObject, JsonObject>(2000, "sendAudioDevicePowerOnMessage", param, hdmiCecSinkResult);
+                    {
+                        UnlockApiGuard unlockApi;
+                        gHdmiCecConnection->Invoke<JsonObject, JsonObject>(2000, "sendAudioDevicePowerOnMessage", param, hdmiCecSinkResult);
+                    }
                     if (!hdmiCecSinkResult["success"].Boolean()) {
                         success = false;
                         LOGERR("HdmiCecSink Plugin returned error\n");
@@ -4150,7 +4162,10 @@ namespace WPEFramework {
                     JsonObject param;
 
                     LOGINFO("Requesting Short Audio Descriptor \n");
-                    gHdmiCecConnection->Invoke<JsonObject, JsonObject>(2000, "requestShortAudioDescriptor", param, hdmiCecSinkResult);
+                    {
+                        UnlockApiGuard unlockApi;
+                        gHdmiCecConnection->Invoke<JsonObject, JsonObject>(2000, "requestShortAudioDescriptor", param, hdmiCecSinkResult);
+                    }
                     if (!hdmiCecSinkResult["success"].Boolean()) {
                         success = false;
                         LOGERR("HdmiCecSink Plugin returned error\n");
@@ -4182,7 +4197,10 @@ namespace WPEFramework {
                     JsonObject param;
 
                     LOGINFO("Requesting Audio Device power Status \n");
-                    gHdmiCecConnection->Invoke<JsonObject, JsonObject>(2000, "requestAudioDevicePowerStatus", param, hdmiCecSinkResult);
+                    {
+                        UnlockApiGuard unlockApi;
+                        gHdmiCecConnection->Invoke<JsonObject, JsonObject>(2000, "requestAudioDevicePowerStatus", param, hdmiCecSinkResult);
+                    }
                     if (!hdmiCecSinkResult["success"].Boolean()) {
                         success = false;
                         LOGERR("HdmiCecSink Plugin returned error\n");

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -28,6 +28,7 @@
 #include "irMgr.h"
 #include "pwrMgr.h"
 #include "rfcapi.h"
+#include "AbstractPluginWithApiAndIARMLock.h"
 
 namespace WPEFramework {
 
@@ -45,7 +46,7 @@ namespace WPEFramework {
 		// As the registration/unregistration of notifications is realized by the class PluginHost::JSONRPC,
 		// this class exposes a public method called, Notify(), using this methods, all subscribed clients
 		// will receive a JSONRPC message as a notification, in case this method is called.
-        class DisplaySettings : public PluginHost::IPlugin, public PluginHost::JSONRPC {
+        class DisplaySettings : public PluginHost::IPlugin, public AbstractPluginWithApiAndIARMLock {
         private:
             typedef Core::JSON::String JString;
             typedef Core::JSON::ArrayType<JString> JStringArray;

--- a/HdcpProfile/HdcpProfile.cpp
+++ b/HdcpProfile/HdcpProfile.cpp
@@ -68,7 +68,7 @@ namespace WPEFramework
         HdcpProfile* HdcpProfile::_instance = nullptr;
 
         HdcpProfile::HdcpProfile()
-        : PluginHost::JSONRPC()
+        // : PluginHost::JSONRPC()
         {
             RegisterAll();
         }

--- a/HdcpProfile/HdcpProfile.generated.json
+++ b/HdcpProfile/HdcpProfile.generated.json
@@ -1,9 +1,0 @@
-{
- "locator":"libWPEFrameworkHdcpProfile.so",
- "classname":"HdcpProfile",
- "precondition":[
-  "Platform"
- ],
- "callsign":"org.rdk.HdcpProfile",
- "autostart":false
-}

--- a/HdcpProfile/HdcpProfile.generated.json
+++ b/HdcpProfile/HdcpProfile.generated.json
@@ -1,0 +1,9 @@
+{
+ "locator":"libWPEFrameworkHdcpProfile.so",
+ "classname":"HdcpProfile",
+ "precondition":[
+  "Platform"
+ ],
+ "callsign":"org.rdk.HdcpProfile",
+ "autostart":false
+}

--- a/HdcpProfile/HdcpProfile.h
+++ b/HdcpProfile/HdcpProfile.h
@@ -23,6 +23,8 @@
 
 #include "Module.h"
 
+#include "AbstractPluginWithApiAndIARMLock.h"
+
 namespace WPEFramework {
 
     namespace Plugin {
@@ -39,7 +41,7 @@ namespace WPEFramework {
 		// As the registration/unregistration of notifications is realized by the class PluginHost::JSONRPC,
 		// this class exposes a public method called, Notify(), using this methods, all subscribed clients
 		// will receive a JSONRPC message as a notification, in case this method is called.
-        class HdcpProfile : public PluginHost::IPlugin, public PluginHost::JSONRPC {
+        class HdcpProfile : public PluginHost::IPlugin, public AbstractPluginWithApiAndIARMLock {
         private:
 
             // We do not allow this plugin to be copied !!

--- a/HdmiCec/HdmiCec.cpp
+++ b/HdmiCec/HdmiCec.cpp
@@ -172,7 +172,7 @@ namespace WPEFramework
 //=========================================== HdmiCec =========================================
 
         HdmiCec::HdmiCec()
-        : PluginHost::JSONRPC(),cecEnableStatus(false),smConnection(nullptr)
+        : cecEnableStatus(false),smConnection(nullptr)
         {
             HdmiCec::_instance = this;
             InitializeIARM();
@@ -1027,7 +1027,7 @@ namespace WPEFramework
 			return;
 		if(!(_instance->smConnection))
 			return;
-		LOGINFO("Entering ThreadRun: _instance->m_pollThreadExit %d",_instance->m_pollThreadExit);
+		LOGINFO("Entering ThreadRun: _instance->m_pollThreadExit %d",_instance->m_pollThreadExit.load());
 		int i = 0;
 		pthread_mutex_lock(&(_instance->m_lock));//pthread_cond_wait should be mutex protected. //pthread_cond_wait will unlock the mutex and perfoms wait for the condition.
 		while (!_instance->m_pollThreadExit) {
@@ -1057,7 +1057,7 @@ namespace WPEFramework
 			return;
 		if(!(_instance->smConnection))
 			return;
-		LOGINFO("Entering ThreadUpdate: _instance->m_updateThreadExit %d",_instance->m_updateThreadExit);
+		LOGINFO("Entering ThreadUpdate: _instance->m_updateThreadExit %d",_instance->m_updateThreadExit.load());
 		int i = 0;
 		pthread_mutex_lock(&(_instance->m_lockUpdate));//pthread_cond_wait should be mutex protected. //pthread_cond_wait will unlock the mutex and perfoms wait for the condition.
 		while (!_instance->m_updateThreadExit) {

--- a/HdmiCec/HdmiCec.h
+++ b/HdmiCec/HdmiCec.h
@@ -30,7 +30,6 @@
 #include "ccec/MessageDecoder.hpp"
 #include "ccec/MessageProcessor.hpp"
 
-
 #undef Assert // this define from Connection.hpp conflicts with WPEFramework
 
 #include "Module.h"
@@ -41,6 +40,8 @@
 
 #include "UtilsBIT.h"
 #include "UtilsThreadRAII.h"
+
+#include "AbstractPluginWithApiAndIARMLock.h"
 
 namespace WPEFramework {
 
@@ -115,7 +116,7 @@ namespace WPEFramework {
 		// As the registration/unregistration of notifications is realized by the class PluginHost::JSONRPC,
 		// this class exposes a public method called, Notify(), using this methods, all subscribed clients
 		// will receive a JSONRPC message as a notification, in case this method is called.
-        class HdmiCec : public PluginHost::IPlugin, public PluginHost::JSONRPC, public FrameListener, public MessageProcessor {
+        class HdmiCec : public PluginHost::IPlugin, public AbstractPluginWithApiAndIARMLock, public FrameListener, public MessageProcessor {
         private:
 
             // We do not allow this plugin to be copied !!
@@ -173,9 +174,9 @@ namespace WPEFramework {
             bool cecEnableStatus;
             Connection *smConnection;
             int m_numberOfDevices;
-            bool m_pollThreadExit;
+            std::atomic_bool m_pollThreadExit;
             Utils::ThreadRAII m_pollThread;
-            bool m_updateThreadExit;
+            std::atomic_bool m_updateThreadExit;
             Utils::ThreadRAII m_UpdateThread;
 
             const void InitializeIARM();

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -101,8 +101,7 @@ namespace {
     const std::string systemRequestKeyValue = "vaLib)6?b%$^CP;/F";
 }
 
-XCast::XCast() : PluginHost::JSONRPC()
-, m_apiVersionNumber(1), m_isDynamicRegistrationsRequired(false)
+XCast::XCast() : m_apiVersionNumber(1), m_isDynamicRegistrationsRequired(false)
 {
     InitializeIARM();
     XCast::checkRFCServiceStatus();

--- a/XCast/XCast.h
+++ b/XCast/XCast.h
@@ -29,6 +29,7 @@
 #include "libIBusDaemon.h"
 #include "pwrMgr.h"
 #include "XCastCommon.h"
+#include "AbstractPluginWithApiAndIARMLock.h"
 
 using namespace std;
 
@@ -47,7 +48,7 @@ namespace Plugin {
 // As the registration/unregistration of notifications is realized by the class PluginHost::JSONRPC,
 // this class exposes a public method called, Notify(), using this methods, all subscribed clients
 // will receive a JSONRPC message as a notification, in case this method is called.
-class XCast : public PluginHost::IPlugin, public PluginHost::JSONRPC, public RtNotifier {
+class XCast : public PluginHost::IPlugin, public AbstractPluginWithApiAndIARMLock, public RtNotifier {
 private:
     
     // We do not allow this plugin to be copied !!

--- a/helpers/AbstractPluginWithApiAndIARMLock.h
+++ b/helpers/AbstractPluginWithApiAndIARMLock.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <mutex>
+#include <libIBus.h>
+#include <AbstractPluginWithApiLock.h>
+#include <map>
+#include <string>
+#include "UtilsLogging.h"
+
+namespace WPEFramework {
+
+    namespace Plugin {
+
+        static std::map<std::string, std::map<IARM_EventId_t, IARM_EventHandler_t>> _registered_iarm_handlers;
+
+        static void _generic_iarm_handler(const char *owner, IARM_EventId_t eventId, void *data, size_t len) {
+            std::lock_guard<std::mutex> lock(AbstractPluginWithApiLock::getApiLock());
+            // we can't be in IARM handler thread & API request thread at the same time, so
+            // it's safe to use AbstractPluginWithApiLock's isThreadUsingLockedApi here
+            isThreadUsingLockedApi = true;
+            try {
+                if (_registered_iarm_handlers[owner].count(eventId)) {
+                    LOGINFO("handling IARM handler under lock: %s/%d len:%d\n",owner, eventId, len);
+                    _registered_iarm_handlers[owner][eventId](owner, eventId, data, len);
+                } else {
+                    LOGERR("missing handler for %s / %d", owner, eventId);
+                }
+            } catch (...) {
+                isThreadUsingLockedApi = false;
+                throw;
+            }
+            isThreadUsingLockedApi = false;
+        }
+        /*
+            provides overloaded versions of IARM_Bus_RegisterEventHandler (and IARM_Bus_UnRegisterEventHandler)
+            that take locks when executing
+        */
+        class AbstractPluginWithApiAndIARMLock : public AbstractPluginWithApiLock {
+        public:
+
+            // we are providing IARM_Bus_RegisterEventHandler as new static member (libiarm provides standalone function)
+            static IARM_Result_t IARM_Bus_RegisterEventHandler(const char *ownerName, IARM_EventId_t eventId, IARM_EventHandler_t handler) {
+                if (_registered_iarm_handlers[ownerName].count(eventId)) {
+                    LOGERR("double registration for %s / %d ; previous handler will be overriden", ownerName, eventId);
+                }
+                _registered_iarm_handlers[ownerName][eventId] = handler;
+                auto ret = ::IARM_Bus_RegisterEventHandler(ownerName, eventId, _generic_iarm_handler);
+                if (IARM_RESULT_SUCCESS != ret) {
+                    _registered_iarm_handlers[ownerName].erase(eventId);
+                }
+                return ret;
+            }
+
+            // we are providing IARM_Bus_UnRegisterEventHandler as new static member (libiarm provides standalone function)
+            static IARM_Result_t IARM_Bus_UnRegisterEventHandler(const char *ownerName, IARM_EventId_t eventId) {
+                _registered_iarm_handlers[ownerName].erase(eventId);
+                return ::IARM_Bus_UnRegisterEventHandler(ownerName, eventId);
+            }
+        };
+    } // Plugin
+} // WPEFramework

--- a/helpers/AbstractPluginWithApiLock.h
+++ b/helpers/AbstractPluginWithApiLock.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <mutex>
+#include <plugins/plugins.h>
+#include <memory>
+#include "UtilsLogging.h"
+
+namespace WPEFramework {
+
+    namespace Plugin {
+
+        namespace {
+            // set when inside of getFunctionToCall wrapper (or locked IARM handler - see AbstractPluginWithApiAndIARMLock)
+            thread_local bool isThreadUsingLockedApi = false;
+        }
+        /*
+            When plugin extends this instead of AbstractPlugin all API method invocations will be mutex protected.
+        */
+        class AbstractPluginWithApiLock : public PluginHost::JSONRPC {
+
+        public:
+
+            template <typename METHOD, typename REALOBJECT>
+            std::function<uint32_t(REALOBJECT*, const WPEFramework::Core::JSON::VariantContainer&, WPEFramework::Core::JSON::VariantContainer&)>
+            getFunctionToCall(const std::string& debugname, const METHOD& method, REALOBJECT* objectPtr) {
+                return [debugname, method](REALOBJECT *obj, const WPEFramework::Core::JSON::VariantContainer& in, WPEFramework::Core::JSON::VariantContainer& out) -> uint32_t {
+                    isThreadUsingLockedApi = true;
+                    std::lock_guard<std::mutex> lock(getApiLock());
+                    LOGINFO("calling with lock: %s\n", debugname.c_str());
+                    uint32_t ret;
+                    try {
+                        ret = (obj->*method)(in, out);
+                    } catch (...) {
+                        isThreadUsingLockedApi = false;
+                        throw;
+                    }
+                    isThreadUsingLockedApi = false;
+                    return ret;
+                };
+            }
+
+
+            /* we are hiding, not overriding, Register */
+            template <typename METHOD, typename REALOBJECT>
+            void Register(const string& methodName, const METHOD& method, REALOBJECT* objectPtr)
+            {
+                using MethodType = decltype(getFunctionToCall(methodName, method, objectPtr));
+                PluginHost::JSONRPC::Register<Core::JSON::VariantContainer, Core::JSON::VariantContainer, MethodType, REALOBJECT>(methodName, getFunctionToCall(methodName, method, objectPtr), objectPtr);
+            }
+
+            /* we are hiding, not overriding, Register */
+            template <typename METHOD, typename REALOBJECT>
+            void Register(const string& methodName, const METHOD& method, REALOBJECT* objectPtr, const std::vector<uint8_t> versions)
+            {
+                PluginHost::JSONRPC::Register<METHOD,REALOBJECT>(methodName, getFunctionToCall(methodName, method, objectPtr), objectPtr, versions);
+            }
+
+            struct HandlerWrapper {
+                HandlerWrapper(Core::JSONRPC::Handler* wrapped, AbstractPluginWithApiLock *parent) : wrapped(wrapped), parent(parent) {
+                }
+                Core::JSONRPC::Handler* wrapped;
+                AbstractPluginWithApiLock* parent;
+
+                template <typename INBOUND, typename OUTBOUND, typename METHOD, typename REALOBJECT>
+                void Register(const string& methodName, const METHOD& method, REALOBJECT* objectPtr)
+                {
+                    using MethodType = decltype(parent->getFunctionToCall(methodName, method, objectPtr));
+                    wrapped->Register<INBOUND,OUTBOUND,MethodType,REALOBJECT>(methodName, parent->getFunctionToCall(methodName, method, objectPtr), objectPtr);
+                }
+
+                template <typename JSONOBJECT>
+                uint32_t Notify(const string& event, const JSONOBJECT& parameters) const
+                {
+                    return wrapped->Notify(event, parameters);
+                }
+
+            };
+
+            /* we are hiding, not overriding, GetHandler; need to return wrapper
+               to be able to replace  Core::JSONRPC::Handler::Register */
+            std::unique_ptr<HandlerWrapper> GetHandler(uint8_t version)
+            {
+                auto* wrapped = PluginHost::JSONRPC::GetHandler(version);
+                return wrapped ? std::unique_ptr<HandlerWrapper>(new HandlerWrapper(wrapped, this)) : nullptr;
+            }
+
+        public:
+            /*
+                This guard can unlock & re-lock api mutex to prevent deadlock possible when calling other plugins via Invoke
+                (could deadlock in case when that other plugin called Invoke on this plugin at the same time, or tried to call
+                this plugin recursively, from the Invoke'd call).
+            */
+            struct UnlockApiGuard {
+                UnlockApiGuard() {
+                    if (isThreadUsingLockedApi) {
+                        getApiLock().unlock();
+                    }
+                }
+                ~UnlockApiGuard() {
+                    if (isThreadUsingLockedApi) {
+                        getApiLock().lock();
+                    }
+                }
+            };
+
+            /* note this will be shared by all subclasses (normally we have 1 plugin per lib, so that's enough) */
+            static std::mutex& getApiLock() {
+                static std::mutex apiLock;
+                return apiLock;
+            }
+        };
+
+    } // Plugin
+} // WPEFramework

--- a/helpers/AbstractPluginWithApiLock.h
+++ b/helpers/AbstractPluginWithApiLock.h
@@ -39,7 +39,6 @@ namespace WPEFramework {
                 };
             }
 
-
             /* we are hiding, not overriding, Register */
             template <typename METHOD, typename REALOBJECT>
             void Register(const string& methodName, const METHOD& method, REALOBJECT* objectPtr)
@@ -49,10 +48,11 @@ namespace WPEFramework {
             }
 
             /* we are hiding, not overriding, Register */
-            template <typename METHOD, typename REALOBJECT>
-            void Register(const string& methodName, const METHOD& method, REALOBJECT* objectPtr, const std::vector<uint8_t> versions)
+            template <typename INBOUND, typename OUTBOUND, typename METHOD, typename REALOBJECT>
+            void Register(const string& methodName, const METHOD& method, REALOBJECT* objectPtr)
             {
-                PluginHost::JSONRPC::Register<METHOD,REALOBJECT>(methodName, getFunctionToCall(methodName, method, objectPtr), objectPtr, versions);
+                using MethodType = decltype(getFunctionToCall(methodName, method, objectPtr));
+                PluginHost::JSONRPC::Register<INBOUND, OUTBOUND, MethodType, REALOBJECT>(methodName, getFunctionToCall(methodName, method, objectPtr), objectPtr);
             }
 
             struct HandlerWrapper {


### PR DESCRIPTION
Review of threading safety (ONEMPERS-397) shows that there are multiple places where rdk plugins state can
be concurrently accessed by parallel threads, without any locking. This PR adds 'apiLock' mutex that assures synchronisation (and serialization) of API method calls & IARM event handlers, to avoid concurrency issues.

Updated plugins are:

DisplaySettings
HdmiCec
HdcpProfile
XCast