### PR TITLE
OMWAPPI-1052 remove some of our Xcast patches

### DIFF
--- a/XCast/CMakeLists.txt
+++ b/XCast/CMakeLists.txt
@@ -18,6 +18,7 @@
 set(PLUGIN_NAME XCast)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
+set(PLUGIN_XCAST_AUTOSTART "false" CACHE STRING "Automatically start XCast plugin")
 set(PLUGIN_XCAST_STARTUPORDER "" CACHE STRING "To configure startup order of XCast plugin")
 
 find_package(${NAMESPACE}Plugins REQUIRED)

--- a/XCast/CMakeLists.txt
+++ b/XCast/CMakeLists.txt
@@ -21,7 +21,6 @@ set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 set(PLUGIN_XCAST_STARTUPORDER "" CACHE STRING "To configure startup order of XCast plugin")
 
 find_package(${NAMESPACE}Plugins REQUIRED)
-find_package(${NAMESPACE}SecurityUtil REQUIRED)
 
 add_library(${MODULE_NAME} SHARED
         XCast.cpp
@@ -30,6 +29,7 @@ add_library(${MODULE_NAME} SHARED
         XCastSystemRemoteObject.cpp
         ../helpers/powerstate.cpp)
 
+find_package(RFC)
 find_package(IARMBus)
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11
@@ -39,9 +39,10 @@ target_compile_definitions(${MODULE_NAME} PRIVATE MODULE_NAME=Plugin_${PLUGIN_NA
 
 add_definitions (-DRT_PLATFORM_LINUX)
 target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS} ../helpers)
+target_include_directories(${MODULE_NAME} PRIVATE ${RFC_INCLUDE_DIRS} ../helpers)
 target_include_directories(${MODULE_NAME} PRIVATE $ENV{PKG_CONFIG_SYSROOT_DIR}/usr/include/pxcore)
 
-target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${NAMESPACE}SecurityUtil::${NAMESPACE}SecurityUtil rtRemote rtCore cjson rfcapi ${IARMBUS_LIBRARIES})
+target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins rtRemote rtCore ${RFC_LIBRARIES} ${IARMBUS_LIBRARIES})
 
 
 install(TARGETS ${MODULE_NAME}

--- a/XCast/CMakeLists.txt
+++ b/XCast/CMakeLists.txt
@@ -43,7 +43,7 @@ target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS} ../hel
 target_include_directories(${MODULE_NAME} PRIVATE ${RFC_INCLUDE_DIRS} ../helpers)
 target_include_directories(${MODULE_NAME} PRIVATE $ENV{PKG_CONFIG_SYSROOT_DIR}/usr/include/pxcore)
 
-target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins rtRemote rtCore ${RFC_LIBRARIES} ${IARMBUS_LIBRARIES})
+target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins rtRemote rtCore cjson ${RFC_LIBRARIES} ${IARMBUS_LIBRARIES})
 
 
 install(TARGETS ${MODULE_NAME}

--- a/XCast/XCast.config
+++ b/XCast/XCast.config
@@ -1,4 +1,4 @@
-set (autostart false)
+set (autostart ${PLUGIN_XCAST_AUTOSTART})
 set (preconditions Platform)
 set (callsign "org.rdk.Xcast")
 

--- a/XCast/XCast.config
+++ b/XCast/XCast.config
@@ -1,6 +1,4 @@
-set(PLUGIN_XCAST_AUTOSTART false CACHE BOOL "Automatically start XCast plugin")
-
-set (autostart ${PLUGIN_XCAST_AUTOSTART})
+set (autostart false)
 set (preconditions Platform)
 set (callsign "org.rdk.Xcast")
 


### PR DESCRIPTION
Revert "ONEMPERS-198: pass XCast autostart from cmake"

replaced now by the patch that we try to upstream (standard way to do that like in the other plugins)

Revert "ONEMPERS-198: fix linking issues with XCast"

proper location of FindRFC.cmake like a Comcast use it is in wpeframework/cmake/modules/FindRFC.cmake