### PR TITLE
Revert "ONEM-21608 - autostart configuration added for playerinfo"

### DIFF
--- a/DisplayInfo/DisplayInfo.cpp
+++ b/DisplayInfo/DisplayInfo.cpp
@@ -59,7 +59,7 @@ namespace Plugin {
         _service->Register(&_notification);
         _skipURL = static_cast<uint8_t>(service->WebPrefix().length());
 
-        _connectionProperties = service->Root<Exchange::IConnectionProperties>(_connectionId, 6000, _T("DisplayInfoImplementation"));
+        _connectionProperties = service->Root<Exchange::IConnectionProperties>(_connectionId, 2000, _T("DisplayInfoImplementation"));
         if (_connectionProperties != nullptr) {
             _connectionProperties->Register(&_notification);
             Exchange::JConnectionProperties::Register(*this, _connectionProperties);

--- a/PlayerInfo/PlayerInfo.cpp
+++ b/PlayerInfo/PlayerInfo.cpp
@@ -64,7 +64,7 @@ namespace Plugin {
         // change to "register" the sink for these events !!! So do it ahead of instantiation.
         _service->Register(&_notification);
 
-        _player = service->Root<Exchange::IPlayerProperties>(_connectionId, 6000, _T("PlayerInfoImplementation"));
+        _player = service->Root<Exchange::IPlayerProperties>(_connectionId, 2000, _T("PlayerInfoImplementation"));
         if (_player != nullptr) {
 
             if ((_player->AudioCodecs(_audioCodecs) == Core::ERROR_NONE) && (_audioCodecs != nullptr)) {


### PR DESCRIPTION
This reverts commit fbf98e6bcfac6d1953359d1787cde1a3c5c6a715.

Justification:
https://jira.lgi.io/browse/OMWAPPI-1052?focusedCommentId=4702147&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-4702147

Verification build done here: https://gerrit.onemw.net/c/meta-lgi-om-common/+/103659