### PR TITLE
OMWAPPI-1061 running unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,7 +12,7 @@ env:
   BUILD_TYPE: Debug
 
   # Refs for 22Q4_sprint
-  THUNDER_REF: "R2-v1.12"
+  THUNDER_REF: "a87b48eca1e76c3e6f03d689e6302b1fb090b52c"
   INTERFACES_REF: "f61d710cc51628819d0fd80b8cc65e55eeec12b4"
 
 jobs:

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -41,6 +41,7 @@ set_source_files_properties(
         tests/test_DeviceVideoCapabilities.cpp
         tests/test_SystemServices.cpp
         tests/test_Warehouse.cpp
+        tests/test_HdcpProfile.cpp
         PROPERTIES COMPILE_FLAGS "-fexceptions")
 
 include_directories(../LocationSync

--- a/helpers/AbstractPluginWithApiAndIARMLock.h
+++ b/helpers/AbstractPluginWithApiAndIARMLock.h
@@ -20,7 +20,7 @@ namespace WPEFramework {
             isThreadUsingLockedApi = true;
             try {
                 if (_registered_iarm_handlers[owner].count(eventId)) {
-                    LOGINFO("handling IARM handler under lock: %s/%d len:%d\n",owner, eventId, len);
+                    LOGINFO("handling IARM handler under lock: %s/%d len:%zu",owner, eventId, len);
                     _registered_iarm_handlers[owner][eventId](owner, eventId, data, len);
                 } else {
                     LOGERR("missing handler for %s / %d", owner, eventId);


### PR DESCRIPTION
- Thunder sha bumped to a87b48eca1e76c3e6f03d689e6302b1fb090b52c, it will not compile otherwise
- adding -fexception to HdcpProfile test (AbstractPluginWithApiAndIARMLock introduces 'catch'
- fixing %d -> %zu in printf format