### PR TITLE
ARRISAPP-85 onIPAddressStatusChanged for ipv6

### DIFF
--- a/LgiNetwork/Network.h
+++ b/LgiNetwork/Network.h
@@ -22,6 +22,8 @@
 #include <cjson/cJSON.h>
 #include <string>
 #include <atomic>
+#include <map>
+#include <utility>
 
 #include "Module.h"
 #include "NetUtils.h"
@@ -113,6 +115,9 @@ namespace WPEFramework {
 
             static void StatusChangeEvent(const std::string id, const std::string status);
             static void NetworkingEvent(const string id, const string event, const std::map<string, string> params);
+            static void IP4ConfigurationChangedEvent(const string id);
+            static void IP6ConfigurationChangedEvent(const string id);
+            void onIpConfigurationChangedEvent(const string interface, const int ipVersion);
             // this one is just to reroute event according to type *and* params
             void onNetworkingEvent(const string id, const string event, const std::map<string, string> params);
 
@@ -142,14 +147,13 @@ namespace WPEFramework {
             string m_stunEndPoint;
             string m_defaultInterface;
             string m_gatewayInterface;
-            string m_oldIpv4;
-            string m_oldIpv6;
+            // (interface id, ip version number) -> ip (string)
+            std::map<std::pair<string, int>, string> m_oldAddresses;
             uint16_t m_stunPort;
             uint16_t m_stunBindTimeout;
             uint16_t m_stunCacheTimeout;
             bool m_stunSync;
             uint32_t m_apiVersionNumber;
-            bool m_dhcpEventSeen;
         };
     } // namespace Plugin
 } // namespace WPEFramework

--- a/LgiNetwork/dbus/lginetwork_client.cpp
+++ b/LgiNetwork/dbus/lginetwork_client.cpp
@@ -44,6 +44,13 @@ public:
         return reinterpret_cast<LgiNetworkClient*>(aUserData)->onHandleIpv4ConfigurationChanged(aNetworkConfigProxy, aId);
     }
 
+    static void cbHandleIPv6ConfigurationChanged(LgiNetworkClient*  aNetworkConfigProxy,
+                                        const gchar*    aId,
+                                        gpointer        aUserData)
+    {
+        return reinterpret_cast<LgiNetworkClient*>(aUserData)->onHandleIpv6ConfigurationChanged(aNetworkConfigProxy, aId);
+    }
+
     static void cbHandleNetworkingEvent(LgiNetworkClient*  aNetworkConfigProxy,
                                         const gchar*    aId,
                                         const gchar*    aEvent,
@@ -295,7 +302,15 @@ void LgiNetworkClient::onHandleNetworkingEvent(LgiNetworkClient*  aNetworkConfig
 void LgiNetworkClient::onHandleIpv4ConfigurationChanged(LgiNetworkClient*  aNetworkConfigProxy,
                                         const gchar*    aId)
 {
-    // nothing yet.
+    if (onHandleIpv4ConfigurationChangedEvent)
+        onHandleIpv4ConfigurationChangedEvent(aId);
+}
+
+void LgiNetworkClient::onHandleIpv6ConfigurationChanged(LgiNetworkClient*  aNetworkConfigProxy,
+                                        const gchar*    aId)
+{
+    if (onHandleIpv6ConfigurationChangedEvent)
+        onHandleIpv6ConfigurationChangedEvent(aId);
 }
 
 void LgiNetworkClient::onHandleStatusChanged(LgiNetworkClient*  aNetworkConfigProxy,
@@ -327,6 +342,11 @@ static void handle_dbus_event(GDBusProxy *proxy,
     {
         const gchar *aId = g_variant_get_string(g_variant_iter_next_value(&iter), NULL);
         DbusHandlerCallbacks::cbHandleIPv4ConfigurationChanged(client, aId, user_data);
+    }
+    else if (signal_name == "IPv6ConfigurationChanged" && num_params == 1)
+    {
+        const gchar *aId = g_variant_get_string(g_variant_iter_next_value(&iter), NULL);
+        DbusHandlerCallbacks::cbHandleIPv6ConfigurationChanged(client, aId, user_data);
     }
     else if (signal_name == "NetworkingEvent" && num_params == 4)
     {

--- a/LgiNetwork/dbus/lginetwork_client.hpp
+++ b/LgiNetwork/dbus/lginetwork_client.hpp
@@ -65,6 +65,7 @@ static const std::string ParamWolProcessTimeout                 = "wol_process.t
 typedef void (*StatusChangeEventHandler)(const std::string id, const std::string status);
 typedef void (*NetworkingEventEventHandler)(const std::string id, const std::string status,
                                             const std::map<std::string, std::string> params);
+typedef void (*IpConfigurationChangedEvent)(const std::string id);
 
 class LgiNetworkClient
 {
@@ -89,6 +90,8 @@ public:
 
     StatusChangeEventHandler onStatusChangeEvent;
     NetworkingEventEventHandler onNetworkingEvent;
+    IpConfigurationChangedEvent onHandleIpv4ConfigurationChangedEvent;
+    IpConfigurationChangedEvent onHandleIpv6ConfigurationChangedEvent;
 
 private:
 
@@ -98,6 +101,8 @@ private:
                                         guint           aCount,
                                         GVariant*       aParams);
     void onHandleIpv4ConfigurationChanged(LgiNetworkClient*  aNetworkConfigProxy,
+                                        const gchar*    aId);
+    void onHandleIpv6ConfigurationChanged(LgiNetworkClient*  aNetworkConfigProxy,
                                         const gchar*    aId);
     void onHandleStatusChanged(LgiNetworkClient*  aNetworkConfigProxy,
                                         const gchar *aId,


### PR DESCRIPTION
- update logic to correctly report onIPAddressStatusChanged for both IP v4 and v6
- also send LOST when DISCONNECTED
- handle IPvXConfigurationChanged events and refresh the IPs when received; necessary to have onIPAddressStatusChanged for IPv6 when rebooting the router/WiFi is lost and reacquired (we get no configuration.changed/network.changed event in such case, and dhcp6.options never actually seems to report ip v6 at all)