### PR TITLE
ARRISAPP-186: cut-off not used HdmiCec plugin functionality

### DIFF
--- a/HdmiCec/HdmiCec.cpp
+++ b/HdmiCec/HdmiCec.cpp
@@ -238,11 +238,12 @@ namespace WPEFramework
             if (Utils::IARM::init())
             {
                 IARM_Result_t res;
+#ifndef LGI_CUSTOM_IMPL
                 //IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<HdmiCec>(IARM_BUS_CECHOST_NAME, IARM_BUS_CECHost_EVENT_DEVICESTATUSCHANGE,cecDeviceStatusEventHandler) ); // It didn't do anything in original service
                 IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<HdmiCec>(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_DAEMON_INITIALIZED,cecMgrEventHandler) );
                 IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<HdmiCec>(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_STATUS_UPDATED,cecMgrEventHandler) );
                 IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<HdmiCec>(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG, dsHdmiEventHandler) );
-#ifdef LGI_CUSTOM_IMPL
+#else
                 IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<HdmiCec>(IARM_BUS_CECHOST_NAME, IARM_BUS_CECHost_EVENT_ACTIVESTATUSCHANGE,cecActiveSourceEventHandler) );
 #endif
             }
@@ -253,11 +254,12 @@ namespace WPEFramework
             if (Utils::IARM::isConnected())
             {
                 IARM_Result_t res;
+#ifndef LGI_CUSTOM_IMPL
                 //IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<HdmiCec>(IARM_BUS_CECHOST_NAME, IARM_BUS_CECHost_EVENT_DEVICESTATUSCHANGE, cecDeviceStatusEventHandler) );
                 IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<HdmiCec>(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_DAEMON_INITIALIZED,cecMgrEventHandler) );
                 IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<HdmiCec>(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_STATUS_UPDATED,cecMgrEventHandler) );
                 IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<HdmiCec>(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG, dsHdmiEventHandler) );
-#ifdef LGI_CUSTOM_IMPL
+#else
                 IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<HdmiCec>(IARM_BUS_CECHOST_NAME, IARM_BUS_CECHost_EVENT_ACTIVESTATUSCHANGE,cecActiveSourceEventHandler) );
 #endif
             }
@@ -463,6 +465,7 @@ namespace WPEFramework
                 return;
             }
 
+#ifndef LGI_CUSTOM_IMPL
             char c;
             IARM_Result_t retVal = IARM_RESULT_SUCCESS;
             retVal = IARM_Bus_Call_with_IPCTimeout(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_API_isAvailable, (void *)&c, sizeof(c), 15000);
@@ -497,7 +500,6 @@ namespace WPEFramework
             if(smConnection)
             {
 
-#ifndef LGI_CUSTOM_IMPL
                 LOGWARN("Start Update thread %p", smConnection );
                 m_updateThreadExit = false;
                 _instance->m_lockUpdate = PTHREAD_MUTEX_INITIALIZER;
@@ -524,9 +526,9 @@ namespace WPEFramework
 		} catch (const std::system_error& e) {
                     LOGERR("exception in creating threadRun %s", e.what());
 	        }
-#endif
 
             }
+#endif
             cecEnableStatus = true;
             return;
         }
@@ -540,10 +542,9 @@ namespace WPEFramework
                 LOGWARN("CEC Already Disabled ");
                 return;
             }
-
+#ifndef LGI_CUSTOM_IMPL
             if (smConnection != NULL)
             {
-#ifndef LGI_CUSTOM_IMPL
                 LOGWARN("Stop Thread %p", smConnection );
 
                 m_updateThreadExit = true;
@@ -556,7 +557,6 @@ namespace WPEFramework
                 //Trigger codition to exit poll loop
                 pthread_cond_signal(&(_instance->m_condSig));
                 LOGWARN("Deleted Thread %p", smConnection );
-#endif
                 //Clear cec device cache.
                 removeAllCecDevices();
 
@@ -576,7 +576,9 @@ namespace WPEFramework
             {
                 libcecInitStatus--;
             }
-
+#else
+            cecEnableStatus = false;
+#endif
             return;
         }
 
@@ -728,7 +730,7 @@ namespace WPEFramework
         void HdmiCec::sendMessage(std::string message)
         {
             LOGINFO("sendMessage ");
-
+#ifndef LGI_CUSTOM_IMPL
             if(true == cecEnableStatus)
             {
                 std::vector <unsigned char> buf;
@@ -754,6 +756,7 @@ namespace WPEFramework
             else
                 LOGWARN("cecEnableStatus=false");
             return;
+#endif
         }
 
         void HdmiCec::sendActiveSourceEvent()


### PR DESCRIPTION
Done in the following way:
=> do not register for not required IARM events:
* IARM_BUS_CECMGR_EVENT_DAEMON_INITIALIZED/IARM_BUS_CECMGR_EVENT_STATUS_UPDATED: cecMgrEventHandler=> onCECDaemonInit and cecStatusUpdated never called
* IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG: dsHdmiEventHandler=> onHdmiHotPlug never called

=> HdmiCec::CECDisable and HdmiCec::CECEnable: implementation just toggle the flag (rest is removed)
=> HdmiCec::sendMessage: stub implementation

As a result plugin functionality limited only to the following functional subset:
* org.rdk.HdmiCec.1.getActiveSourceStatus
* onActiveSourceStatusUpdated event

all the other methods/events:
 * org.rdk.HdmiCec.1.setEnabled/org.rdk.HdmiCec.1.getEnabled - just toggle the flag
 * scanning of HDMI CEC devices not performed: org.rdk.HdmiCec.1.getDeviceList return empty list always
 * not possible to send CEC message via plugin: org.rdk.HdmiCec.1.sendMessage is stub
 * org.rdk.HdmiCec.1.getCECAddresses - return only default values: {"jsonrpc":"2.0","id":1,"result":{"CECAddresses":{"physicalAddress":252645135,"logicalAddress":255,"deviceType":"None"},"success":true}} // 252645135 is 0F0F0F0F
 * events: onDeviceAdded/onDeviceRemoved/onDeviceChanged/onMessage will never be generated