### PR TITLE
OMWAPPI-1614 wait for lgias 'ready' in OpenCDMi

### DIFF
--- a/OpenCDMi/LibertyConfig.h
+++ b/OpenCDMi/LibertyConfig.h
@@ -57,6 +57,7 @@ class ASConfig: public ASConnector::events {
 
   private:
     void OnWatchData(ASConnector::DataSource src, const std::string& alias, json_t* data) override final;
+    bool waitForReady(std::unique_lock<std::mutex>& lck);
 
     std::shared_ptr<ASConnector> _ASConnector;
     std::mutex _ConfigMtx;
@@ -64,6 +65,7 @@ class ASConfig: public ASConnector::events {
     std::string _Company;
     std::string _Model;
     std::string _BuildInfo;
+    bool _AsReady {false};
 };
 
 std::string updateWidevineConfig(const std::string& widevineConfigStr, ASConfig& asConfig);


### PR DESCRIPTION
Since we're using lgias config, we should wait for application services 'ready' event before we expect to get some lgias data.