### PR TITLE
ARRISAPP-285: upstream patch to fork

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -246,6 +246,9 @@ namespace WPEFramework {
             registerMethodLockedApi("setZoomSetting", &DisplaySettings::setZoomSetting, this);
             registerMethodLockedApi("getCurrentResolution", &DisplaySettings::getCurrentResolution, this);
             registerMethodLockedApi("setCurrentResolution", &DisplaySettings::setCurrentResolution, this);
+            registerMethodLockedApi("setCurrentResolutionOwner", &DisplaySettings::setCurrentResolutionOwner, this);
+            registerMethodLockedApi("getEnableVideoPort", &DisplaySettings::getEnableVideoPort, this);
+            registerMethodLockedApi("setEnableVideoPort", &DisplaySettings::setEnableVideoPort, this);
             registerMethodLockedApi("getSoundMode", &DisplaySettings::getSoundMode, this);
             registerMethodLockedApi("setSoundMode", &DisplaySettings::setSoundMode, this);
             registerMethodLockedApi("readEDID", &DisplaySettings::readEDID, this);
@@ -1370,7 +1373,7 @@ namespace WPEFramework {
             bool hasPersist = parameters.HasLabel("persist");
             bool persist = hasPersist ? parameters["persist"].Boolean() : true;
             if (!hasPersist) LOGINFO("persist: true");
- 
+
             bool isIgnoreEdidArg = parameters.HasLabel("ignoreEdid");
             bool isIgnoreEdid = isIgnoreEdidArg ? parameters["ignoreEdid"].Boolean() : false;
             if (!isIgnoreEdidArg) LOGINFO("isIgnoreEdid: false"); else LOGINFO("isIgnoreEdid: %d", isIgnoreEdid);
@@ -1379,7 +1382,17 @@ namespace WPEFramework {
             try
             {
                 device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort(videoDisplay);
-                vPort.setResolution(resolution, persist, isIgnoreEdid);
+
+                if (parameters.HasLabel("owner")) {
+                  string owner = parameters["owner"].String();
+                  if (parameters.HasLabel("timeout")) {
+                    uint32_t timeout = parameters["timeout"].Number();
+                    vPort.setResolutionOwner(owner.c_str(), timeout);
+                  }
+                  vPort.setResolutionByOwner(resolution, owner.c_str());
+                } else {
+                  vPort.setResolution(resolution, persist, isIgnoreEdid);
+                }
             }
             catch (const device::Exception& err)
             {
@@ -1388,6 +1401,88 @@ namespace WPEFramework {
             }
             returnResponse(success);
         }
+
+        uint32_t DisplaySettings::getEnableVideoPort (const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool success = true;
+
+            returnIfParamNotFound(parameters, "videoDisplay");
+            string videoDisplay = parameters["videoDisplay"].String();
+
+            try
+            {
+                device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort(videoDisplay);
+                bool isEnabled;
+
+                isEnabled = vPort.isEnabled();
+                response["enabled"] = isEnabled;
+            }
+            catch (const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION1(videoDisplay);
+                success = false;
+            }
+
+            returnResponse(success);
+        }
+
+        uint32_t DisplaySettings::setEnableVideoPort (const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool success = true;
+
+
+            returnIfParamNotFound(parameters, "videoDisplay");
+            returnIfParamNotFound(parameters, "enabled");
+
+            string  videoDisplay = parameters["videoDisplay"].String();
+            bool    isEnabled    = parameters["enabled"].Boolean();
+
+            try
+            {
+                device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort(videoDisplay);
+                if (isEnabled) {
+                  vPort.enable();
+                } else {
+                  vPort.disable();
+                }
+            }
+            catch (const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION1(videoDisplay);
+                success = false;
+            }
+
+            returnResponse(success);
+        }
+
+
+        uint32_t DisplaySettings::setCurrentResolutionOwner(const JsonObject& parameters, JsonObject& response)
+        {   //sample servicemanager response:
+            LOGINFOMETHOD();
+            returnIfParamNotFound(parameters, "videoDisplay");
+            returnIfParamNotFound(parameters, "owner");
+            returnIfParamNotFound(parameters, "timeout");
+
+            string   videoDisplay = parameters["videoDisplay"].String();
+            string   owner        = parameters["owner"].String();
+            uint32_t timeout      = parameters["timeout"].Number();
+
+            bool success = true;
+            try
+            {
+                device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort(videoDisplay);
+                vPort.setResolutionOwner(owner.c_str(), timeout);
+            }
+            catch (const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION2(videoDisplay, owner);
+                success = false;
+            }
+            returnResponse(success);
+        }
+
 
         uint32_t DisplaySettings::getSoundMode(const JsonObject& parameters, JsonObject& response)
         {   //sample servicemanager response:{"success":true,"soundMode":"AUTO (Dolby Digital 5.1)"}

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -69,6 +69,9 @@ namespace WPEFramework {
             uint32_t setZoomSetting(const JsonObject& parameters, JsonObject& response);
             uint32_t getCurrentResolution(const JsonObject& parameters, JsonObject& response);
             uint32_t setCurrentResolution(const JsonObject& parameters, JsonObject& response);
+            uint32_t setCurrentResolutionOwner(const JsonObject& parameters, JsonObject& response);
+            uint32_t getEnableVideoPort (const JsonObject& parameters, JsonObject& response);
+            uint32_t setEnableVideoPort (const JsonObject& parameters, JsonObject& response);
             uint32_t getSoundMode(const JsonObject& parameters, JsonObject& response);
             uint32_t setSoundMode(const JsonObject& parameters, JsonObject& response);
             uint32_t readEDID(const JsonObject& parameters, JsonObject& response);


### PR DESCRIPTION
Upstream patch 0001-displaysettings-lgi-extensions.patch to LGI fork.

Added API added to:
a) set resolution change onwer (to block resolution change by other modules during a follow framerate trasnition) 
b) get port video enabled status
c) enable/disable video port

author: Roman Slipko (rslipko@libertyglobal.com)

validation: https://gerrit.onemw.net/c/meta-lgi-om-common/+/107945/1/