### PR TITLE
ONEM-30654: Fix enabling mixed content

### DIFF
--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -2790,7 +2790,6 @@ static GSourceFuncs _handlerIntervention =
             // Allow mixed content.
             bool enableWebSecurity = _config.Secure.Value();
             g_object_set(G_OBJECT(preferences),
-                     "enable-websecurity", enableWebSecurity,
                      "allow-running-of-insecure-content", !enableWebSecurity,
                      "allow-display-of-insecure-content", !enableWebSecurity, nullptr);
 


### PR DESCRIPTION
"enable-websecurity" property no longer exists, it has been replaced by "disable-web-security"
"disable-web-security" is not related to mixed content though, it disables the same-origin policy, so it's best not to touch it in this case