### PR TITLE
ARRISAPP-394 add STEREO_SURROUND_MAT_FOLLOW

### DIFF
--- a/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
@@ -270,6 +270,7 @@ public:
             else if(amode == device::AudioStereoMode::kStereo) mode = STEREO;
             else if(amode == device::AudioStereoMode::kMono) mode = MONO;
             else if(amode == device::AudioStereoMode::kPassThru) mode = PASSTHRU;
+            else if(amode == device::AudioStereoMode::kSurroundMatFollow) mode = STEREO_SURROUND_MAT_FOLLOW;
             else mode = UNKNOWN;
             PlayerInfoImplementation::_instance->audiomodeChanged(mode, true);
         }
@@ -387,6 +388,7 @@ public:
                 else if(soundmode == device::AudioStereoMode::kStereo) mode = STEREO;
                 else if(soundmode == device::AudioStereoMode::kMono) mode = MONO;
                 else if(soundmode == device::AudioStereoMode::kPassThru) mode = PASSTHRU;
+                else if(soundmode == device::AudioStereoMode::kSurroundMatFollow) mode = STEREO_SURROUND_MAT_FOLLOW;
                 else mode = UNKNOWN;
 
                 /* Auto mode applicable for HDMI Arc and SPDIF */

--- a/PlayerInfo/PlayerInfo.json
+++ b/PlayerInfo/PlayerInfo.json
@@ -194,7 +194,8 @@
                     "Mono",
                     "Stereo",
                     "Surround",
-                    "Passthru"
+                    "Passthru",
+                    "StereoSurroundMatFollow"
                 ],
                 "example": "Unknown"
             }
@@ -236,7 +237,8 @@
                             "Mono",
                             "Stereo",
                             "Surround",
-                            "Passthru"
+                            "Passthru",
+                            "StereoSurroundMatFollow"
                         ],
                         "example": "Unknown"
                     },


### PR DESCRIPTION
While kSurroundMatFollow has been added ([OMWAPPI-1653](https://jira.lgi.io/browse/OMWAPPI-1653)),
the support is still missing in thunder PlayerInfo plugin.

The change depends on update in wpeframework interfaces (device::AudioStereoMode::kSurroundMatFollow must also be added there)