### PR TITLE
ONEM-30768 Add ODH report for OCDM secure store operations

### DIFF
--- a/OpenCDMi/FrameworkRPC.cpp
+++ b/OpenCDMi/FrameworkRPC.cpp
@@ -98,6 +98,16 @@ namespace Plugin {
         }
     }
 
+    static void ReportSecureStoreHash(const char* reportMsg, const std::string& keySystem, const uint8_t* storeHash, uint16_t storeHashLength) {
+        std::stringstream hash;
+        hash << std::uppercase << std::hex;
+        for (unsigned int i = 0; i < storeHashLength; i++)
+        {
+            hash << static_cast<int>(storeHash[i]);
+        }
+        ODH_ERROR_REPORT_CTX_ERROR(0, reportMsg, keySystem, hash.str());
+    }
+
     static const TCHAR BufferFileName[] = _T("ocdmbuffer.");
 
     class OCDMImplementation : public Exchange::IContentDecryption {
@@ -741,7 +751,22 @@ namespace Plugin {
 
                 Exchange::OCDM_RESULT StoreLicenseData(const uint8_t licenseData[], uint16_t licenseDataSize, unsigned char* secureStopId) override
                 {
-                    return (Exchange::OCDM_RESULT)_mediaKeySessionExt->StoreLicenseData(licenseData, licenseDataSize, secureStopId);
+                    Exchange::OCDM_RESULT result = (Exchange::OCDM_RESULT)_mediaKeySessionExt->StoreLicenseData(licenseData, licenseDataSize, secureStopId);
+                    if (result == Exchange::OCDM_SUCCESS)
+                    {
+                        // Report hash of the store after license was stored
+                        CDMi::IMediaKeysExt *systemExt = dynamic_cast<CDMi::IMediaKeysExt *>(_parent._parent.KeySystem(_keySystem));
+                        if (systemExt)
+                        {
+                            std::vector<uint8_t> drmStoreHash(32);
+                            Exchange::OCDM_RESULT hashResult = (Exchange::OCDM_RESULT) systemExt->GetSecureStoreHash(&drmStoreHash[0], drmStoreHash.size());
+                            if (hashResult == Exchange::OCDM_SUCCESS)
+                            {
+                                ReportSecureStoreHash("StoreLicenseData", _keySystem, &drmStoreHash[0], drmStoreHash.size());
+                            }
+                        }
+                    }
+                    return result;
                 }
 
                 Exchange::OCDM_RESULT SelectKeyId(const uint8_t keyLength, const uint8_t keyId[]) override
@@ -1074,6 +1099,7 @@ namespace Plugin {
             {
                 CDMi::IMediaKeysExt* systemExt = dynamic_cast<CDMi::IMediaKeysExt*>(_parent.KeySystem(keySystem));
                 if (systemExt) {
+                    ODH_ERROR_REPORT_CTX_ERROR(0, "DeleteSecureStore", keySystem);
                     return (Exchange::OCDM_RESULT)systemExt->DeleteSecureStore();
                 }
                 return Exchange::OCDM_RESULT::OCDM_S_FALSE;
@@ -1098,7 +1124,12 @@ namespace Plugin {
             {
                 CDMi::IMediaKeysExt* systemExt = dynamic_cast<CDMi::IMediaKeysExt*>(_parent.KeySystem(keySystem));
                 if (systemExt) {
-                    return (Exchange::OCDM_RESULT)systemExt->GetSecureStoreHash(secureStoreHash, secureStoreHashLength);
+                    Exchange::OCDM_RESULT result = (Exchange::OCDM_RESULT)systemExt->GetSecureStoreHash(secureStoreHash, secureStoreHashLength);
+                    if (result == Exchange::OCDM_SUCCESS)
+                    {
+                        ReportSecureStoreHash("GetSecureStoreHash", keySystem, secureStoreHash, secureStoreHashLength);
+                    }
+                    return result;
                 }
                 return Exchange::OCDM_RESULT::OCDM_S_FALSE;
             }


### PR DESCRIPTION
This change is just temporary to collect data on how often OCDM secure store gets modified or deleted.