### PR TITLE
ONEM-30706 OMI upstreaming

### DIFF
--- a/OCIContainer/CMakeLists.txt
+++ b/OCIContainer/CMakeLists.txt
@@ -3,12 +3,20 @@ set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
 set(PLUGIN_OCICONTAINER_STARTUPORDER "" CACHE STRING "To configure startup order of OCIContainer plugin")
 
+find_package(PkgConfig)
 find_package(${NAMESPACE}Plugins REQUIRED)
 find_package(jsoncpp REQUIRED)
 find_package(Dobby REQUIRED CONFIG)
 
 # Temporary fix to get defines in Dobby. Will be removed later.
 add_definitions( -DRDK )
+
+pkg_search_module(OMI_CLIENT "omiclientlib")
+
+if(NOT OMI_CLIENT_FOUND)
+    set(OMI_CLIENT_INCLUDE_DIRS stubs)
+    message("Using stubs for omiclientlib")
+endif()
 
 add_library(${MODULE_NAME} SHARED
         OCIContainer.cpp
@@ -41,7 +49,9 @@ find_package_handle_standard_args(
 target_include_directories(${MODULE_NAME}
         PRIVATE
         ../helpers
-        )
+        ${OMI_CLIENT_INCLUDE_DIRS}
+)
+
 
 target_link_libraries(${MODULE_NAME}
         PRIVATE
@@ -52,23 +62,10 @@ target_link_libraries(${MODULE_NAME}
         AppInfraCommon
         AppInfraLogging
         JsonCpp::JsonCpp
-
+        ${OMI_CLIENT_LIBRARIES}
         ${NAMESPACE}Plugins::${NAMESPACE}Plugins
         ${SYSTEMD_LIBRARIES}
 )
-
-
-find_library(OMIPROXY omiclientlib)
-if(OMIPROXY)
-
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I=/usr/include/glib-2.0 -I=/usr/lib/glib-2.0/include")
-  target_link_libraries (${MODULE_NAME} PRIVATE omiclientlib)
-
-else()
-
-  target_include_directories(${MODULE_NAME} PRIVATE stubs)
-
-endif (OMIPROXY)
 
 # ${NAMESPACE}Protocols::${NAMESPACE}Protocols
 install(TARGETS ${MODULE_NAME}

--- a/OCIContainer/CMakeLists.txt
+++ b/OCIContainer/CMakeLists.txt
@@ -41,7 +41,6 @@ find_package_handle_standard_args(
 target_include_directories(${MODULE_NAME}
         PRIVATE
         ../helpers
-
         )
 
 target_link_libraries(${MODULE_NAME}
@@ -57,6 +56,20 @@ target_link_libraries(${MODULE_NAME}
         ${NAMESPACE}Plugins::${NAMESPACE}Plugins
         ${SYSTEMD_LIBRARIES}
 )
+
+
+find_library(OMIPROXY omiclientlib)
+if(OMIPROXY)
+
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I=/usr/include/glib-2.0 -I=/usr/lib/glib-2.0/include")
+  target_link_libraries (${MODULE_NAME} PRIVATE omiclientlib)
+
+else()
+
+  target_include_directories(${MODULE_NAME} PRIVATE stubs)
+
+endif (OMIPROXY)
+
 # ${NAMESPACE}Protocols::${NAMESPACE}Protocols
 install(TARGETS ${MODULE_NAME}
         DESTINATION lib/${STORAGE_DIRECTORY}/plugins)

--- a/OCIContainer/OCIContainer.cpp
+++ b/OCIContainer/OCIContainer.cpp
@@ -366,8 +366,15 @@ uint32_t OCIContainer::startContainerFromCryptedBundle(const JsonObject &paramet
     // startContainer returns -1 on failure
     if (descriptor <= 0)
     {
-        LOGERR("Failed to start container - internal Dobby error.");
-        response["error"] = "internal dobby error";
+        LOGERR("Failed to start container - internal Dobby error. Unmounting container.");
+
+        if (!mOmiProxy->umountCryptedBundle(id.c_str())) {
+            LOGERR("Failed to umount container %s - sync unmount request to omi failed.", id.c_str());
+            response["error"] = "dobby start failed, unmount failed";
+        } else {
+            response["error"] = "dobby start failed";
+        }
+
         returnResponse(false);
     }
 

--- a/OCIContainer/OCIContainer.cpp
+++ b/OCIContainer/OCIContainer.cpp
@@ -162,6 +162,7 @@ uint32_t OCIContainer::getContainerState(const JsonObject &parameters, JsonObjec
     int cd = GetContainerDescriptorFromId(id);
     if (cd < 0)
     {
+        response["error"] = "container descriptor can not be acquired";
         returnResponse(false);
     }
 
@@ -218,6 +219,7 @@ uint32_t OCIContainer::getContainerInfo(const JsonObject &parameters, JsonObject
     int cd = GetContainerDescriptorFromId(id);
     if (cd < 0)
     {
+        response["error"] = "container descriptor can not be acquired";
         returnResponse(false);
     }
 
@@ -226,6 +228,7 @@ uint32_t OCIContainer::getContainerInfo(const JsonObject &parameters, JsonObject
     if (containerInfoString.empty())
     {
         LOGERR("Failed to get info for container %s", id.c_str());
+        response["error"] = "failed to get container info";
         returnResponse(false);
     }
 
@@ -234,6 +237,7 @@ uint32_t OCIContainer::getContainerInfo(const JsonObject &parameters, JsonObject
     WPEC::OptionalType<WPEJ::Error> error;
     if (!WPEJ::IElement::FromString(containerInfoString, containerInfoJson, error)) {
         LOGERR("Failed to parse Dobby Spec JSON due to: %s", WPEJ::ErrorDisplayMessage(error).c_str());
+        response["error"] = "failed to parse dobby spec";
         returnResponse(false);
     }
 
@@ -334,9 +338,9 @@ uint32_t OCIContainer::startContainerFromCryptedBundle(const JsonObject &paramet
                                        containerPath))
     {
         LOGERR("Failed to start container - sync mount request to omi failed.");
+        response["error"] = "mount failed";
         returnResponse(false);
     }
-
 
     LOGINFO("Mount request to omi succeeded, contenerPath: %s", containerPath.c_str());
 
@@ -363,6 +367,7 @@ uint32_t OCIContainer::startContainerFromCryptedBundle(const JsonObject &paramet
     if (descriptor <= 0)
     {
         LOGERR("Failed to start container - internal Dobby error.");
+        response["error"] = "internal dobby error";
         returnResponse(false);
     }
 
@@ -456,6 +461,7 @@ uint32_t OCIContainer::stopContainer(const JsonObject &parameters, JsonObject &r
     int cd = GetContainerDescriptorFromId(id);
     if (cd < 0)
     {
+        response["error"] = "container descriptor can not be acquired";
         returnResponse(false);
     }
 
@@ -467,6 +473,7 @@ uint32_t OCIContainer::stopContainer(const JsonObject &parameters, JsonObject &r
     if (!stoppedSuccessfully)
     {
         LOGERR("Failed to stop container - internal Dobby error.");
+        response["error"] = "internal dobby error";
         returnResponse(false);
     }
 
@@ -492,6 +499,7 @@ uint32_t OCIContainer::pauseContainer(const JsonObject &parameters, JsonObject &
     int cd = GetContainerDescriptorFromId(id);
     if (cd < 0)
     {
+        response["error"] = "container descriptor can not be acquired";
         returnResponse(false);
     }
 
@@ -500,6 +508,7 @@ uint32_t OCIContainer::pauseContainer(const JsonObject &parameters, JsonObject &
     if (!pausedSuccessfully)
     {
         LOGERR("Failed to pause container - internal Dobby error.");
+        response["error"] = "internal dobby error";
         returnResponse(false);
     }
 
@@ -525,6 +534,7 @@ uint32_t OCIContainer::resumeContainer(const JsonObject &parameters, JsonObject 
     int cd = GetContainerDescriptorFromId(id);
     if (cd < 0)
     {
+        response["error"] = "container descriptor can not be acquired";
         returnResponse(false);
     }
 
@@ -533,6 +543,7 @@ uint32_t OCIContainer::resumeContainer(const JsonObject &parameters, JsonObject 
     if (!resumedSuccessfully)
     {
         LOGERR("Failed to resume container - internal Dobby error.");
+        response["error"] = "internal dobby error";
         returnResponse(false);
     }
 
@@ -561,6 +572,7 @@ uint32_t OCIContainer::executeCommand(const JsonObject &parameters, JsonObject &
     int cd = GetContainerDescriptorFromId(id);
     if (cd < 0)
     {
+        response["error"] = "container descriptor can not be acquired";
         returnResponse(false);
     }
 
@@ -572,6 +584,7 @@ uint32_t OCIContainer::executeCommand(const JsonObject &parameters, JsonObject &
     if (!executedSuccessfully)
     {
         LOGERR("Failed to execute command in container - internal Dobby error.");
+        response["error"] = "internal dobby error";
         returnResponse(false);
     }
 
@@ -601,6 +614,7 @@ void OCIContainer::onContainerStarted(int32_t descriptor, const std::string& nam
  */
 void OCIContainer::onContainerStopped(int32_t descriptor, const std::string& name)
 {
+
     if (!mOmiProxy->umountCryptedBundle(name))
     {
         LOGERR("Failed to umount container %s - sync unmount request to omi failed.", name.c_str());

--- a/OCIContainer/OCIContainer.cpp
+++ b/OCIContainer/OCIContainer.cpp
@@ -2,6 +2,7 @@
 
 #include <Dobby/DobbyProxy.h>
 #include <Dobby/IpcService/IpcFactory.h>
+#include <omi_proxy.hpp>
 
 #include "UtilsJsonRpc.h"
 
@@ -41,6 +42,7 @@ OCIContainer::OCIContainer()
     Register("getContainerState", &OCIContainer::getContainerState, this);
     Register("getContainerInfo", &OCIContainer::getContainerInfo, this);
     Register("startContainer", &OCIContainer::startContainer, this);
+    Register("startContainerFromCryptedBundle", &OCIContainer::startContainerFromCryptedBundle, this);
     Register("startContainerFromDobbySpec", &OCIContainer::startContainerFromDobbySpec, this);
     Register("stopContainer", &OCIContainer::stopContainer, this);
     Register("pauseContainer", &OCIContainer::pauseContainer, this);
@@ -50,6 +52,7 @@ OCIContainer::OCIContainer()
 
 OCIContainer::~OCIContainer()
 {
+
 }
 
 const string OCIContainer::Initialize(PluginHost::IShell *service)
@@ -74,16 +77,22 @@ const string OCIContainer::Initialize(PluginHost::IShell *service)
     // Register a state change event listener
     mEventListenerId = mDobbyProxy->registerListener(stateListener, static_cast<const void*>(this));
 
+    mOmiProxy = std::make_shared<omi::OmiProxy>();
+
+    mOmiListenerId = mOmiProxy->registerListener(omiErrorListener, static_cast<const void*>(this));
+
     return string();
 }
 
 void OCIContainer::Deinitialize(PluginHost::IShell *service)
 {
     mDobbyProxy->unregisterListener(mEventListenerId);
+    mOmiProxy->unregisterListener(mOmiListenerId);
     Unregister("listContainers");
     Unregister("getContainerState");
     Unregister("getContainerInfo");
     Unregister("startContainer");
+    Unregister("startContainerFromCryptedBundle");
     Unregister("startContainerFromDobbySpec");
     Unregister("stopContainer");
     Unregister("pauseContainer");
@@ -275,6 +284,79 @@ uint32_t OCIContainer::startContainer(const JsonObject &parameters, JsonObject &
             westerosSocket = "";
         }
         descriptor = mDobbyProxy->startContainerFromBundle(id, bundlePath, emptyList, command, westerosSocket);
+    }
+
+    // startContainer returns -1 on failure
+    if (descriptor <= 0)
+    {
+        LOGERR("Failed to start container - internal Dobby error.");
+        returnResponse(false);
+    }
+
+    response["descriptor"] = descriptor;
+    returnResponse(true);
+}
+
+/**
+ * @brief Starts a container from a crypted OCI bundle
+ *
+ * @param[in]  parameters   - Must include 'containerId', 'rootFSPath' and 'configFilePath'.
+ * @param[out] response     - Dobby descriptor of the started container.
+ *
+ * @return                  A code indicating success.
+ */
+uint32_t OCIContainer::startContainerFromCryptedBundle(const JsonObject &parameters, JsonObject &response)
+{
+    LOGINFO("Start container from crypted OCI bundle");
+
+    // To start a container, we need a path to an OCI bundle and an ID for the container
+    returnIfStringParamNotFound(parameters, "containerId");
+    returnIfStringParamNotFound(parameters, "rootFSPath");
+    returnIfStringParamNotFound(parameters, "configFilePath");
+
+    std::string id = parameters["containerId"].String();
+    std::string rootfsPath = parameters["rootFSPath"].String();
+    std::string configPath = parameters["configFilePath"].String();
+    std::string command = parameters["command"].String();
+    std::string westerosSocket = parameters["westerosSocket"].String();
+
+    // Can be used to pass file descriptors to container construction.
+    // Currently unsupported, see DobbyProxy::startContainerFromBundle().
+    std::list<int> emptyList;
+
+    int descriptor;
+
+    std::string containerPath;
+
+    if (!mOmiProxy->mountCryptedBundle(id,
+                                       rootfsPath,
+                                       configPath,
+                                       containerPath))
+    {
+        LOGERR("Failed to start container - sync mount request to omi failed.");
+        returnResponse(false);
+    }
+
+
+    LOGINFO("Mount request to omi succeeded, contenerPath: %s", containerPath.c_str());
+
+    // If no additional arguments, start the container
+    if ((command == "null" || command.empty()) && (westerosSocket == "null" || westerosSocket.empty()))
+    {
+        descriptor = mDobbyProxy->startContainerFromBundle(id, containerPath, emptyList);
+    }
+    else
+    {
+        // Dobby expects empty strings if values not set
+        if (command == "null" || command.empty())
+        {
+            command = "";
+        }
+        if (westerosSocket == "null" || westerosSocket.empty())
+        {
+            westerosSocket = "";
+        }
+        descriptor = mDobbyProxy->startContainerFromBundle(id, containerPath, emptyList, command, westerosSocket);
     }
 
     // startContainer returns -1 on failure
@@ -519,6 +601,15 @@ void OCIContainer::onContainerStarted(int32_t descriptor, const std::string& nam
  */
 void OCIContainer::onContainerStopped(int32_t descriptor, const std::string& name)
 {
+    if (!mOmiProxy->umountCryptedBundle(name))
+    {
+        LOGERR("Failed to umount container %s - sync unmount request to omi failed.", name.c_str());
+    }
+    else
+    {
+        LOGINFO("Container %s properly unmounted.", name.c_str());
+    }
+
     JsonObject params;
     params["descriptor"] = std::to_string(descriptor);
     params["name"] = name;
@@ -589,6 +680,61 @@ const void OCIContainer::stateListener(int32_t descriptor, const std::string& na
         LOGINFO("Received an unknown state event for container '%s'.", name.c_str());
     }
 }
+
+/**
+ * @brief Callback listener for OMI error events.
+ *
+ * @param id         Container id
+ * @param err        Error type
+ * @param _this      Callback parameters, or in this case, the pointer to 'this'
+ */
+const void OCIContainer::omiErrorListener(const std::string& id, omi::IOmiProxy::ErrorType err, const void* _this)
+{
+
+    // Cast const void* back to OCIContainer* type to get 'this'
+    OCIContainer* __this = const_cast<OCIContainer*>(reinterpret_cast<const OCIContainer*>(_this));
+
+    if (err == omi::IOmiProxy::ErrorType::verityFailed)
+    {
+        __this->onVerityFailed(id);
+    }
+    else
+    {
+        LOGINFO("Received an unknown error type from OMI");
+    }
+}
+
+/**
+ * @brief Handle failure of verity check for container.
+ *
+ * @param name          Container name.
+ */
+void OCIContainer::onVerityFailed(const std::string& name)
+{
+    LOGINFO("Handle onVerityFailed");
+    int cd = GetContainerDescriptorFromId(name);
+    if (cd < 0)
+    {
+        LOGERR("Failed to acquire container descriptor - cannot stop container due to verity failure");
+        return;
+    }
+
+    JsonObject params;
+    params["descriptor"] = cd;
+    params["name"] = name;
+    // Set error type to Verity Error (1)
+    params["errorCode"] = 1;
+    sendNotify("onContainerFailed", params);
+
+    bool stoppedSuccessfully = mDobbyProxy->stopContainer(cd, true);
+
+    if (!stoppedSuccessfully)
+    {
+        LOGERR("Failed to stop container - internal Dobby error.");
+        return;
+    }
+}
+
 // End Internal methods
 
 } // namespace Plugin

--- a/OCIContainer/OCIContainer.h
+++ b/OCIContainer/OCIContainer.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include <map>
+#include <i_omi_proxy.hpp>
 
 namespace WPEFramework
 {
@@ -38,6 +39,7 @@ public:
     uint32_t getContainerState(const JsonObject &parameters, JsonObject &response);
     uint32_t getContainerInfo(const JsonObject &parameters, JsonObject &response);
     uint32_t startContainer(const JsonObject &parameters, JsonObject &response);
+    uint32_t startContainerFromCryptedBundle(const JsonObject &parameters, JsonObject &response);
     uint32_t startContainerFromDobbySpec(const JsonObject &parameters, JsonObject &response);
     uint32_t stopContainer(const JsonObject &parameters, JsonObject &response);
     uint32_t pauseContainer(const JsonObject &parameters, JsonObject &response);
@@ -48,6 +50,7 @@ public:
     //Begin events
     void onContainerStarted(int32_t descriptor, const std::string& name);
     void onContainerStopped(int32_t descriptor, const std::string& name);
+    void onVerityFailed(const std::string& name);
     //End events
 
     //Build QueryInterface implementation, specifying all possible interfaces to be returned.
@@ -65,10 +68,13 @@ public:
 
 private:
     int mEventListenerId; // Dobby event listener ID
+    long unsigned mOmiListenerId;
     std::shared_ptr<IDobbyProxy> mDobbyProxy; // DobbyProxy instance
     std::shared_ptr<AI_IPC::IIpcService> mIpcService; // Ipc Service instance
     const int GetContainerDescriptorFromId(const std::string& containerId);
     static const void stateListener(int32_t descriptor, const std::string& name, IDobbyProxyEvents::ContainerState state, const void* _this);
+    static const void omiErrorListener(const std::string& id, omi::IOmiProxy::ErrorType err, const void* _this);
+    std::shared_ptr<omi::IOmiProxy> mOmiProxy;
 };
 } // namespace Plugin
 } // namespace WPEFramework

--- a/OCIContainer/OCIContainer.json
+++ b/OCIContainer/OCIContainer.json
@@ -368,6 +368,63 @@
                 ]
             }
         },
+        "startContainerFromCryptedBundle":{
+            "summary": "Starts a new container from an existing encrypted OCI bundle",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "containerId": {
+                        "$ref": "#/definitions/containerId"
+                    },
+                    "rootFSPath": {
+                        "summary": "Path to the enrypted OCI bundle containing the rootfs to use to create the container",
+                        "type": "string",
+                        "example": "/containers/rootfs/myBundle"
+                    },
+                    "configFilePath": {
+                        "summary": "Path to the enrypted OCI bundle containing the config file to use to create the container",
+                        "type": "string",
+                        "example": "/containers/var/myBundle"
+                    },
+                    "command": {
+                        "$ref": "#/definitions/command"
+                    },
+                    "westerosSocket":{
+                        "summary": "Path to a Westeros socket to mount inside the container",
+                        "type": "string",
+                        "example": "/usr/mySocket"
+                    },
+                    "envvar": {
+                        "summary": "A list of environment variables to add to the container",
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "example": "FOO=BAR"
+                        }
+                    }
+                },
+                "required": [
+                    "containerId",
+                    "rootFSPath",
+                    "configFilePath"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "descriptor": {
+                        "$ref": "#/definitions/Descriptor"
+                    },
+                    "success":{
+                        "$ref": "#/definitions/success"
+                    }
+                },
+                "required": [
+                    "descriptor",
+                    "success"
+                ]
+            }
+        },
         "startContainerFromDobbySpec":{
             "summary": "Starts a new container from a legacy Dobby JSON specification.",
             "events": {

--- a/OCIContainer/OCIContainer.json
+++ b/OCIContainer/OCIContainer.json
@@ -41,6 +41,32 @@
             "summary":"Name of the Container.",
             "type":"string",
             "example":"com.bskyb.epgui"
+        },
+        "result": {
+            "type":"object",
+            "properties": {
+                "success": {
+                    "$ref": "#/common/success"
+                },
+                "error":{
+                        "summary": "An error message in case of a failure",
+                        "type": "string",
+                        "example": "internal dobby error"
+                }
+            },
+            "required": [
+                "success"
+            ]
+        },
+        "success": {
+            "summary": "Whether the request succeeded",
+            "type": "boolean",
+            "example": "true"
+        },
+        "error": {
+            "summary": "Error message",
+            "type": "string",
+            "example": "mount failed"
         }
     },
     "methods": {
@@ -194,6 +220,11 @@
                     },
                     "success":{
                         "$ref": "#/common/success"
+                    },
+                    "error":{
+                        "summary": "An error message in case of a failure",
+                        "type": "string",
+                        "example": "internal dobby error"
                     }
                 },
                 "required": [
@@ -235,6 +266,11 @@
                     },
                     "success":{
                         "$ref": "#/common/success"
+                    },
+                    "error":{
+                        "summary": "An error message in case of a failure",
+                        "type": "string",
+                        "example": "could not remove symlink"
                     }
                 },
                 "required": [
@@ -416,7 +452,12 @@
                         "$ref": "#/definitions/Descriptor"
                     },
                     "success":{
-                        "$ref": "#/definitions/success"
+                        "$ref": "#/common/success"
+                    },
+                    "error":{
+                        "summary": "An error message in case of a failure",
+                        "type": "string",
+                        "example": "internal dobby error"
                     }
                 },
                 "required": [

--- a/OCIContainer/doc/OCIContainerPlugin.md
+++ b/OCIContainer/doc/OCIContainerPlugin.md
@@ -1,0 +1,590 @@
+The RDK Services documentation is hosted as a static web site.
+
+**Version: 1.0**
+
+**Status: :black_circle::black_circle::black_circle:**
+
+org.rdk.OCIContainer plugin for Thunder framework.
+
+### Table of Contents
+
+- [Introduction](#head.Introduction)
+- [Description](#head.Description)
+- [Configuration](#head.Configuration)
+- [Methods](#head.Methods)
+
+<a name="head.Introduction"></a>
+# Introduction
+
+<a name="head.Scope"></a>
+## Scope
+
+This document describes purpose and functionality of the org.rdk.OCIContainer plugin. It includes detailed specification about its configuration and methods provided.
+
+<a name="head.Case_Sensitivity"></a>
+## Case Sensitivity
+
+All identifiers of the interfaces described in this document are case-sensitive. Thus, unless stated otherwise, all keywords, entities, properties, relations and actions should be treated as such.
+
+<a name="head.Acronyms,_Abbreviations_and_Terms"></a>
+## Acronyms, Abbreviations and Terms
+
+The table below provides and overview of acronyms used in this document and their definitions.
+
+| Acronym | Description |
+| :-------- | :-------- |
+| <a name="acronym.API">API</a> | Application Programming Interface |
+| <a name="acronym.HTTP">HTTP</a> | Hypertext Transfer Protocol |
+| <a name="acronym.JSON">JSON</a> | JavaScript Object Notation; a data interchange format |
+| <a name="acronym.JSON-RPC">JSON-RPC</a> | A remote procedure call protocol encoded in JSON |
+
+The table below provides and overview of terms and abbreviations used in this document and their definitions.
+
+| Term | Description |
+| :-------- | :-------- |
+| <a name="term.callsign">callsign</a> | The name given to an instance of a plugin. One plugin can be instantiated multiple times, but each instance the instance name, callsign, must be unique. |
+
+<a name="head.References"></a>
+## References
+
+| Ref ID | Description |
+| :-------- | :-------- |
+| <a name="ref.HTTP">[HTTP](http://www.w3.org/Protocols)</a> | HTTP specification |
+| <a name="ref.JSON-RPC">[JSON-RPC](https://www.jsonrpc.org/specification)</a> | JSON-RPC 2.0 specification |
+| <a name="ref.JSON">[JSON](http://www.json.org/)</a> | JSON specification |
+| <a name="ref.Thunder">[Thunder](https://github.com/WebPlatformForEmbedded/Thunder/blob/master/doc/WPE%20-%20API%20-%20WPEFramework.docx)</a> | Thunder API Reference |
+
+<a name="head.Description"></a>
+# Description
+
+The `OCIContainer` plugin allows for control of OCI containers using the Dobby hypervisor.
+
+The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#ref.Thunder)].
+
+<a name="head.Configuration"></a>
+# Configuration
+
+The table below lists configuration options of the plugin.
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| callsign | string | Plugin instance name (default: *org.rdk.OCIContainer*) |
+| classname | string | Class name: *org.rdk.OCIContainer* |
+| locator | string | Library name: *libWPEFrameworkOCIContainer.so* |
+| autostart | boolean | Determines if the plugin shall be started automatically along with the framework |
+
+<a name="head.Methods"></a>
+# Methods
+
+The following methods are provided by the org.rdk.OCIContainer plugin:
+
+OCIContainer interface methods:
+
+| Method | Description |
+| :-------- | :-------- |
+| [execCommand](#method.execCommand) | Executes a command inside a running container |
+| [getContainerInfo](#method.getContainerInfo) | Gets information about a running container such as CPU, memory, and GPU usage (GPU not supported on Xi6) |
+| [getContainerState](#method.getContainerState) | Gets the state of a currently running container |
+| [listContainers](#method.listContainers) | Lists all running OCI containers Dobby knows about |
+| [pauseContainer](#method.pauseContainer) | Pauses a currently running container |
+| [resumeContainer](#method.resumeContainer) | Resumes a previously paused container |
+| [startContainer](#method.startContainer) | Starts a new container from an existing OCI bundle |
+| [startContainerFromDobbySpec](#method.startContainerFromDobbySpec) | Starts a new container from a legacy Dobby JSON specification |
+| [stopContainer](#method.stopContainer) | Stops a currently running container |
+
+
+<a name="method.execCommand"></a>
+## *execCommand <sup>method</sup>*
+
+Executes a command inside a running container. The path to the executable must resolve within the container's namespace.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.containerId | string | The ID of a container as returned by `listContainers` |
+| params?.options | string | <sup>*(optional)*</sup> Global options for crun `exec` command |
+| params.command | string | Command to execute |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+| result.error | string | Error information |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "org.rdk.OCIContainer.1.execCommand",
+    "params": {
+        "containerId": "com.bskyb.epgui",
+        "options": "--cwd=PATH",
+        "command": "command"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": {
+        "success": true
+    }
+}
+```
+
+<a name="method.getContainerInfo"></a>
+## *getContainerInfo <sup>method</sup>*
+
+Gets information about a running container such as CPU, memory, and GPU usage (GPU not supported on Xi6).
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.containerId | string | The ID of a container as returned by `listContainers` |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.info | object | Information about the specified container |
+| result.info.cpu | object | CPU information |
+| result.info.cpu.usage | object | The amount of CPU usage |
+| result.info.cpu.usage.percpu | array | The usage for each CPU |
+| result.info.cpu.usage.percpu[#] | integer |  |
+| result.info.cpu.usage.total | integer | The combined usage for all CPUs |
+| result.info.id | string | The ID of a container as returned by `listContainers` |
+| result.info.memory | object | The amount of memory being used by the container |
+| result.info.memory.user | object | User memory statistics |
+| result.info.memory.user.failcnt | integer | The fail count; the number of times that the usage counter hit its limit |
+| result.info.memory.user.limit | integer | The memory limit |
+| result.info.memory.user.max | integer | The maximum amount of memory used |
+| result.info.memory.user.usage | integer | The current memory being used |
+| result.info.pids | array | A list of container process IDs |
+| result.info.pids[#] | integer |  |
+| result.info.state | string | The container state (must be one of the following: *Invalid*, *Starting*, *Running*, *Stopped*, *Paused*) |
+| result.info.timestamp | integer | The timestamp for container information |
+| result.success | boolean | Whether the request succeeded |
+| result.error | string | Error information |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "org.rdk.OCIContainer.1.getContainerInfo",
+    "params": {
+        "containerId": "com.bskyb.epgui"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": {
+        "info": {
+            "cpu": {
+                "usage": {
+                    "percpu": [
+                        83134464184
+                    ],
+                    "total": 224025108679
+                }
+            },
+            "id": "com.bskyb.epgui",
+            "memory": {
+                "user": {
+                    "failcnt": 0,
+                    "limit": 230686720,
+                    "max": 38555648,
+                    "usage": 28655616
+                }
+            },
+            "pids": [
+                7644
+            ],
+            "state": "Running",
+            "timestamp": 6849968158125
+        },
+        "success": true
+    }
+}
+```
+
+<a name="method.getContainerState"></a>
+## *getContainerState <sup>method</sup>*
+
+Gets the state of a currently running container.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.containerId | string | The ID of a container as returned by `listContainers` |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.containerId | string | The ID of a container as returned by `listContainers` |
+| result.state | string | The container state (must be one of the following: *Invalid*, *Starting*, *Running*, *Stopped*, *Paused*) |
+| result.success | boolean | Whether the request succeeded |
+| result.error | string | Error information |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "org.rdk.OCIContainer.1.getContainerState",
+    "params": {
+        "containerId": "com.bskyb.epgui"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": {
+        "containerId": "com.bskyb.epgui",
+        "state": "Running",
+        "success": true
+    }
+}
+```
+
+<a name="method.listContainers"></a>
+## *listContainers <sup>method</sup>*
+
+Lists all running OCI containers Dobby knows about.
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.containers | array | A list of running containers |
+| result.containers[#] | object |  |
+| result.containers[#].Descriptor | integer | The container descriptor |
+| result.containers[#].Id | string | The container Id |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "org.rdk.OCIContainer.1.listContainers"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": {
+        "containers": [
+            {
+                "Descriptor": 91,
+                "Id": "com.bskyb.epgui"
+            }
+        ],
+        "success": true
+    }
+}
+```
+
+<a name="method.pauseContainer"></a>
+## *pauseContainer <sup>method</sup>*
+
+Pauses a currently running container.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.containerId | string | The ID of a container as returned by `listContainers` |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+| result.error | string | Error information |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "org.rdk.OCIContainer.1.pauseContainer",
+    "params": {
+        "containerId": "com.bskyb.epgui"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": {
+        "success": true
+    }
+}
+```
+
+<a name="method.resumeContainer"></a>
+## *resumeContainer <sup>method</sup>*
+
+Resumes a previously paused container.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.containerId | string | The ID of a container as returned by `listContainers` |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+| result.error | string | Error information |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "org.rdk.OCIContainer.1.resumeContainer",
+    "params": {
+        "containerId": "com.bskyb.epgui"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": {
+        "success": true
+    }
+}
+```
+
+<a name="method.startContainer"></a>
+## *startContainer <sup>method</sup>*
+
+Starts a new container from an existing OCI bundle.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.containerId | string | The ID of a container as returned by `listContainers` |
+| params.bundlePath | string | Path to the OCI bundle containing the rootfs and config to use to create the container |
+| params?.command | string | <sup>*(optional)*</sup> Command to execute |
+| params?.westerosSocket | string | <sup>*(optional)*</sup> Path to a Westeros socket to mount inside the container |
+| params?.envvar | array | <sup>*(optional)*</sup> A list of environment variables to add to the container |
+| params?.envvar[#] | string | <sup>*(optional)*</sup>  |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.descriptor | integer | The container descriptor |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "org.rdk.OCIContainer.1.startContainer",
+    "params": {
+        "containerId": "com.bskyb.epgui",
+        "bundlePath": "/containers/myBundle",
+        "command": "command",
+        "westerosSocket": "/usr/mySocket",
+        "envvar": [
+            "FOO=BAR"
+        ]
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": {
+        "descriptor": 91,
+        "success": true
+    }
+}
+```
+
+<a name="method.startContainerFromDobbySpec"></a>
+## *startContainerFromDobbySpec <sup>method</sup>*
+
+Starts a new container from a legacy Dobby JSON specification.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.containerId | string | The ID of a container as returned by `listContainers` |
+| params.dobbySpec | string | Dobby specification to use for the container |
+| params?.command | string | <sup>*(optional)*</sup> Command to execute |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.descriptor | integer | The container descriptor |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "org.rdk.OCIContainer.1.startContainerFromDobbySpec",
+    "params": {
+        "containerId": "com.bskyb.epgui",
+        "dobbySpec": "/containers/dobbySpec",
+        "command": "command"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": {
+        "descriptor": 91,
+        "success": true
+    }
+}
+```
+
+<a name="method.stopContainer"></a>
+## *stopContainer <sup>method</sup>*
+
+Stops a currently running container.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.containerId | string | The ID of a container as returned by `listContainers` |
+| params?.force | boolean | <sup>*(optional)*</sup> If `true`, force stop the container using the `SIGKILL` signal). Otherwise, use the `SIGTERM` signal. The default value if no value is specified is `false` |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+| result.error | string | Error information |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "org.rdk.OCIContainer.1.stopContainer",
+    "params": {
+        "containerId": "com.bskyb.epgui",
+        "force": true
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": {
+        "success": true
+    }
+}
+```
+
+This file will be removed in a future release. The API markdown files for RDK services are located in the [docs/api](https://github.com/rdkcentral/rdkservices/tree/main/docs/api) folder. Please update your bookmarks accordingly.

--- a/OCIContainer/stubs/i_omi_proxy.hpp
+++ b/OCIContainer/stubs/i_omi_proxy.hpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, LIBERTY GLOBAL all rights reserved.
+ */
+
+#ifndef I_OMI_PROXY_HPP_
+#define I_OMI_PROXY_HPP_
+
+#include <string>
+#include <functional>
+
+namespace omi
+{
+
+/**
+ *  @interface IOmiProxy
+ *  @brief Wrapper around an omi_dbus_api that provides simpler method
+ *  calls and give possibility to register/unregister for incoming signals.
+ */
+class IOmiProxy
+{
+public:
+    enum class ErrorType { verityFailed };
+
+    typedef std::function<void(const std::string&, ErrorType, const void*)> OmiErrorListener;
+
+    // Mount crypted bundle
+    // id               [IN]  - Container ID in reverse domain name notation
+    // rootfs_file_path [IN]  - Absolute pathname for filesystem image
+    // config_json_path [IN]  - Absolute pathname for config.json.jwt
+    // bundlePath       [OUT] - Absolute pathname for decrypted config.json payload
+    // Returns TRUE on success, FALSE on error
+    virtual bool mountCryptedBundle(const std::string& id,
+                                    const std::string& rootfs_file_path,
+                                    const std::string& config_json_path,
+                                    std::string& bundlePath /*out parameter*/) = 0;
+
+    // Unmount crypted bundle
+    // id               [IN]  - Container ID in reverse domain name notation
+    // Returns TRUE on success, FALSE on error
+    virtual bool umountCryptedBundle(const std::string& id) = 0;
+
+    // Register listener
+    // listener         [IN]  - OMI error listener which will be called on error event occurrence
+    // Returns listener ID (0<) or 0 on error
+    virtual long unsigned registerListener(const OmiErrorListener &listener, const void* cbParams) = 0;
+
+    // Unregister listener
+    // tag           [IN]  - ID which defines listener to be unregistered
+    virtual void unregisterListener(long unsigned tag) = 0;
+
+};
+} // namespace omi
+#endif // #ifndef I_OMI_PROXY_HPP_

--- a/OCIContainer/stubs/omi_proxy.hpp
+++ b/OCIContainer/stubs/omi_proxy.hpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, LIBERTY GLOBAL all rights reserved.
+ */
+
+#ifndef OMI_PROXY_HPP_
+#define OMI_PROXY_HPP_
+
+#include <i_omi_proxy.hpp>
+
+namespace omi
+{
+
+class OmiProxy : public IOmiProxy
+{
+public:
+    OmiProxy() = default;
+    virtual ~OmiProxy() = default;
+
+    virtual bool mountCryptedBundle(const std::string& id,
+                                       const std::string& rootfs_file_path,
+                                       const std::string& config_json_path,
+                                       std::string& bundlePath) { return true; }
+
+    virtual bool umountCryptedBundle(const std::string& id) { return true; }
+
+    virtual long unsigned registerListener(const OmiErrorListener &listener, const void* cbParams) { return 0; }
+
+    virtual void unregisterListener(long unsigned tag) {}
+};
+
+} // namespace omi
+
+#endif // OMI_PROXY_HPP_


### PR DESCRIPTION
 Changelog:
     - Prepares OMI to be upstreamed
     - Fixes OMI mount leakage in case of Dobby start failure.
    
    Note: it's the same as https://github.com/LibertyGlobal/rdkservices/pull/258
    
 no_jenkins

In order to apply cleanly this patch the following were also cherry-picked:

commit 35a99df1e46f9604bcd128adccbd9e35c64e2b8a
Author: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>
Date:   Wed Jul 5 14:56:37 2023 +0200

    [OCIContainer] Improve error reporting.
    
    Cherry picks missing patch from branch: lgi-main-20220329
    https://github.com/LibertyGlobal/rdkservices/commit/7ce738ef7a8cd71665f68a768b2163fbe224daea

commit 206e08d124a83927cefde8ff587267321873bc62
Author: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>
Date:   Wed Jul 5 14:48:31 2023 +0200

    ONEM-19817: Extend OCIContainer Thunder Plugin to support crypted
    
    Cherry picks missing patch from branch: lgi-main-20220329
    https://github.com/LibertyGlobal/rdkservices/commit/acfd215f79a9b9e2b314683fcee7206a4d083e7c