### PR TITLE
ONEM-31369: Implement whitelist for mixed content

### DIFF
--- a/WebKitBrowser/Extension/CMakeLists.txt
+++ b/WebKitBrowser/Extension/CMakeLists.txt
@@ -30,7 +30,7 @@ option(PLUGIN_WEBKITBROWSER_CUSTOM_PROCESS_INFO "Enable set of custom process in
 
 add_library(${MODULE_NAME} SHARED
     main.cpp
-    WhiteListedOriginDomainsList.cpp
+    CORSWhiteListedOriginDomainsList.cpp
     MixedContentWhiteListedOriginDomainsList.cpp
     Milestone.cpp
     NotifyWPEFramework.cpp

--- a/WebKitBrowser/Extension/CMakeLists.txt
+++ b/WebKitBrowser/Extension/CMakeLists.txt
@@ -31,6 +31,7 @@ option(PLUGIN_WEBKITBROWSER_CUSTOM_PROCESS_INFO "Enable set of custom process in
 add_library(${MODULE_NAME} SHARED
     main.cpp
     WhiteListedOriginDomainsList.cpp
+    MixedContentWhiteListedOriginDomainsList.cpp
     Milestone.cpp
     NotifyWPEFramework.cpp
     RequestHeaders.cpp

--- a/WebKitBrowser/Extension/CORSWhiteListedOriginDomainsList.h
+++ b/WebKitBrowser/Extension/CORSWhiteListedOriginDomainsList.h
@@ -17,47 +17,33 @@
  * limitations under the License.
  */
 
-#ifndef __WHITELISTEDORIGINDOMAINSLIST_H
-#define __WHITELISTEDORIGINDOMAINSLIST_H
+#ifndef __CORSWHITELISTEDORIGINDOMAINSLIST_H
+#define __CORSWHITELISTEDORIGINDOMAINSLIST_H
 
 #include "Module.h"
 
-#include <wpe/webkit-web-extension.h>
-#include <vector>
-#include <map>
-#include <memory>
+#include "WhitelistBase.h"
 
 namespace WPEFramework {
 namespace WebKit {
 
-    class WhiteListedOriginDomainsList {
-    private:
-        WhiteListedOriginDomainsList(const WhiteListedOriginDomainsList&) = delete;
-        WhiteListedOriginDomainsList& operator=(const WhiteListedOriginDomainsList&) = delete;
-
+    class CORSWhiteListedOriginDomainsList final : public WhitelistBase {
     public:
+        CORSWhiteListedOriginDomainsList(const char* jsonString);
+        ~CORSWhiteListedOriginDomainsList() {}
+
+        void AddToWebKit(WebKitWebExtension* extension);
+    private:
+        CORSWhiteListedOriginDomainsList(const CORSWhiteListedOriginDomainsList&) = delete;
+        CORSWhiteListedOriginDomainsList& operator=(const CORSWhiteListedOriginDomainsList&) = delete;
+
         typedef std::pair<bool, string> Domain;
         typedef std::vector<Domain> Domains;
         typedef std::map<string, Domains> WhiteMap;
-
-    public:
-        static std::unique_ptr<WhiteListedOriginDomainsList> Parse(const char* whitelist);
-
-        ~WhiteListedOriginDomainsList()
-        {
-        }
-
-    public:
-        void AddWhiteListToWebKit(WebKitWebExtension* extension);
-
-    private:
-        WhiteListedOriginDomainsList()
-        {
-        }
 
         WhiteMap _whiteMap;
     };
 }
 }
 
-#endif // __WHITELISTEDORIGINDOMAINSLIST_H
+#endif // __CORSWHITELISTEDORIGINDOMAINSLIST_H

--- a/WebKitBrowser/Extension/MixedContentWhiteListedOriginDomainsList.cpp
+++ b/WebKitBrowser/Extension/MixedContentWhiteListedOriginDomainsList.cpp
@@ -6,44 +6,15 @@ using std::vector;
 namespace WPEFramework {
 namespace WebKit {
 
-    /* static */unique_ptr<MixedContentWhiteListedOriginDomainsList> MixedContentWhiteListedOriginDomainsList::Parse(const char* jsonString)
+    MixedContentWhiteListedOriginDomainsList::MixedContentWhiteListedOriginDomainsList(const char* jsonString)
     {
-        // Origin/Domain pair stored in JSON string.
-        class JSONEntry : public Core::JSON::Container {
-        private:
-            JSONEntry& operator=(const JSONEntry&) = delete;
-
-        public:
-            JSONEntry()
-                : Core::JSON::Container()
-                , Origin()
-                , Domain()
-            {
-                Add(_T("origin"), &Origin);
-                Add(_T("domain"), &Domain);
-            }
-            JSONEntry(const JSONEntry& rhs)
-                : Core::JSON::Container()
-                , Origin(rhs.Origin)
-                , Domain(rhs.Domain)
-            {
-                Add(_T("origin"), &Origin);
-                Add(_T("domain"), &Domain);
-            }
-
-        public:
-            Core::JSON::String Origin;
-            Core::JSON::ArrayType<Core::JSON::String> Domain;
-        };
-
         Core::JSON::ArrayType<JSONEntry> entries;
         entries.FromString(jsonString);
         Core::JSON::ArrayType<JSONEntry>::Iterator originIndex(entries.Elements());
-        unique_ptr<MixedContentWhiteListedOriginDomainsList> whiteList(new MixedContentWhiteListedOriginDomainsList());
 
         while (originIndex.Next() == true) {
             if ((originIndex.Current().Origin.IsSet() == true) && (originIndex.Current().Domain.IsSet() == true)) {
-                MixedContentWhiteListedOriginDomainsList::Domains& domains(whiteList->_whiteMap[originIndex.Current().Origin.Value()]);
+                MixedContentWhiteListedOriginDomainsList::Domains& domains(_whiteMap[originIndex.Current().Origin.Value()]);
 
                 Core::JSON::ArrayType<Core::JSON::String>::Iterator domainIndex(originIndex.Current().Domain.Elements());
 
@@ -52,11 +23,10 @@ namespace WebKit {
                 }
             }
         }
-        return whiteList;
     }
 
     // Adds stored entries to WebKit.
-    void MixedContentWhiteListedOriginDomainsList::AddMixedContentWhitelistToWebKit(WebKitWebExtension* extension)
+    void MixedContentWhiteListedOriginDomainsList::AddToWebKit(WebKitWebExtension* extension)
     {
         auto it = _whiteMap.begin();
 

--- a/WebKitBrowser/Extension/MixedContentWhiteListedOriginDomainsList.cpp
+++ b/WebKitBrowser/Extension/MixedContentWhiteListedOriginDomainsList.cpp
@@ -1,0 +1,71 @@
+#include "MixedContentWhiteListedOriginDomainsList.h"
+
+using std::unique_ptr;
+using std::vector;
+
+namespace WPEFramework {
+namespace WebKit {
+
+    /* static */unique_ptr<MixedContentWhiteListedOriginDomainsList> MixedContentWhiteListedOriginDomainsList::Parse(const char* jsonString)
+    {
+        // Origin/Domain pair stored in JSON string.
+        class JSONEntry : public Core::JSON::Container {
+        private:
+            JSONEntry& operator=(const JSONEntry&) = delete;
+
+        public:
+            JSONEntry()
+                : Core::JSON::Container()
+                , Origin()
+                , Domain()
+            {
+                Add(_T("origin"), &Origin);
+                Add(_T("domain"), &Domain);
+            }
+            JSONEntry(const JSONEntry& rhs)
+                : Core::JSON::Container()
+                , Origin(rhs.Origin)
+                , Domain(rhs.Domain)
+            {
+                Add(_T("origin"), &Origin);
+                Add(_T("domain"), &Domain);
+            }
+
+        public:
+            Core::JSON::String Origin;
+            Core::JSON::ArrayType<Core::JSON::String> Domain;
+        };
+
+        Core::JSON::ArrayType<JSONEntry> entries;
+        entries.FromString(jsonString);
+        Core::JSON::ArrayType<JSONEntry>::Iterator originIndex(entries.Elements());
+        unique_ptr<MixedContentWhiteListedOriginDomainsList> whiteList(new MixedContentWhiteListedOriginDomainsList());
+
+        while (originIndex.Next() == true) {
+            if ((originIndex.Current().Origin.IsSet() == true) && (originIndex.Current().Domain.IsSet() == true)) {
+                MixedContentWhiteListedOriginDomainsList::Domains& domains(whiteList->_whiteMap[originIndex.Current().Origin.Value()]);
+
+                Core::JSON::ArrayType<Core::JSON::String>::Iterator domainIndex(originIndex.Current().Domain.Elements());
+
+                while (domainIndex.Next()) {
+                    domains.emplace_back(domainIndex.Current().Value());
+                }
+            }
+        }
+        return whiteList;
+    }
+
+    // Adds stored entries to WebKit.
+    void MixedContentWhiteListedOriginDomainsList::AddMixedContentWhitelistToWebKit(WebKitWebExtension* extension)
+    {
+        auto it = _whiteMap.begin();
+
+        while (it != _whiteMap.end()) {
+            for (const std::string& domain : it->second) {
+                webkit_web_extension_add_mixed_content_whitelist_entry(extension, it->first.c_str(), domain.c_str());
+            }
+            it++;
+        }
+    }
+}
+}

--- a/WebKitBrowser/Extension/MixedContentWhiteListedOriginDomainsList.h
+++ b/WebKitBrowser/Extension/MixedContentWhiteListedOriginDomainsList.h
@@ -1,0 +1,39 @@
+#ifndef __MIXEDCONTENTWHITELISTEDORIGINDOMAINSLIST_H
+#define __MIXEDCONTENTWHITELISTEDORIGINDOMAINSLIST_H
+
+#include "Module.h"
+
+#include <wpe/webkit-web-extension.h>
+#include <vector>
+#include <map>
+#include <memory>
+
+namespace WPEFramework {
+namespace WebKit {
+
+    class MixedContentWhiteListedOriginDomainsList {
+    public:
+        static std::unique_ptr<MixedContentWhiteListedOriginDomainsList> Parse(const char* jsonString);
+
+        ~MixedContentWhiteListedOriginDomainsList()
+        {
+        }
+
+        void AddMixedContentWhitelistToWebKit(WebKitWebExtension* extension);
+
+    private:
+        typedef std::vector<std::string> Domains;
+
+        MixedContentWhiteListedOriginDomainsList(const MixedContentWhiteListedOriginDomainsList&) = delete;
+        MixedContentWhiteListedOriginDomainsList& operator=(const MixedContentWhiteListedOriginDomainsList&) = delete;
+        
+        MixedContentWhiteListedOriginDomainsList()
+        {
+        }
+
+        std::map<std::string, Domains> _whiteMap;
+    };
+}
+}
+
+#endif // __MIXEDCONTENTWHITELISTEDORIGINDOMAINSLIST_H

--- a/WebKitBrowser/Extension/MixedContentWhiteListedOriginDomainsList.h
+++ b/WebKitBrowser/Extension/MixedContentWhiteListedOriginDomainsList.h
@@ -3,34 +3,22 @@
 
 #include "Module.h"
 
-#include <wpe/webkit-web-extension.h>
-#include <vector>
-#include <map>
-#include <memory>
+#include "WhitelistBase.h"
 
 namespace WPEFramework {
 namespace WebKit {
 
-    class MixedContentWhiteListedOriginDomainsList {
+    class MixedContentWhiteListedOriginDomainsList final : public WhitelistBase {
     public:
-        static std::unique_ptr<MixedContentWhiteListedOriginDomainsList> Parse(const char* jsonString);
+        MixedContentWhiteListedOriginDomainsList(const char* jsonString);
+        ~MixedContentWhiteListedOriginDomainsList() {}
 
-        ~MixedContentWhiteListedOriginDomainsList()
-        {
-        }
-
-        void AddMixedContentWhitelistToWebKit(WebKitWebExtension* extension);
-
+        void AddToWebKit(WebKitWebExtension* extension);
     private:
-        typedef std::vector<std::string> Domains;
-
         MixedContentWhiteListedOriginDomainsList(const MixedContentWhiteListedOriginDomainsList&) = delete;
         MixedContentWhiteListedOriginDomainsList& operator=(const MixedContentWhiteListedOriginDomainsList&) = delete;
-        
-        MixedContentWhiteListedOriginDomainsList()
-        {
-        }
 
+        typedef std::vector<std::string> Domains;
         std::map<std::string, Domains> _whiteMap;
     };
 }

--- a/WebKitBrowser/Extension/WhitelistBase.h
+++ b/WebKitBrowser/Extension/WhitelistBase.h
@@ -1,0 +1,56 @@
+#ifndef __WHITELISTBASE_H
+#define __WHITELISTBASE_H
+
+#include "Module.h"
+
+#include <wpe/webkit-web-extension.h>
+#include <vector>
+#include <map>
+#include <memory>
+
+namespace WPEFramework {
+namespace WebKit {
+
+    // Origin/Domain pair stored in JSON string.
+    class JSONEntry : public Core::JSON::Container {
+    private:
+        JSONEntry& operator=(const JSONEntry&) = delete;
+
+    public:
+        JSONEntry()
+            : Core::JSON::Container()
+            , Origin()
+            , Domain()
+        {
+            Add(_T("origin"), &Origin);
+            Add(_T("domain"), &Domain);
+        }
+
+        JSONEntry(const JSONEntry& rhs)
+            : Core::JSON::Container()
+            , Origin(rhs.Origin)
+            , Domain(rhs.Domain)
+        {
+            Add(_T("origin"), &Origin);
+            Add(_T("domain"), &Domain);
+        }
+
+        virtual ~JSONEntry() {}
+
+        Core::JSON::String Origin;
+        Core::JSON::ArrayType<Core::JSON::String> Domain;
+    };
+
+    class WhitelistBase {
+    public:
+        virtual ~WhitelistBase() {}
+        virtual void AddToWebKit(WebKitWebExtension* extension) = 0;
+
+    private:
+        WhitelistBase& operator=(const JSONEntry&) = delete;
+    };
+
+}
+}
+
+#endif // __WHITELISTBASE_H

--- a/WebKitBrowser/Extension/main.cpp
+++ b/WebKitBrowser/Extension/main.cpp
@@ -32,6 +32,7 @@
 #include "NotifyWPEFramework.h"
 #include "RequestHeaders.h"
 #include "WhiteListedOriginDomainsList.h"
+#include "MixedContentWhiteListedOriginDomainsList.h"
 
 #ifdef ENABLE_SECURITY_AGENT
 #include "SecurityAgent.h"
@@ -99,8 +100,9 @@ public:
 
         const char *uid;
         const char *whitelist;
+        const char *mixedContentWhitelist;
 
-        g_variant_get((GVariant*) userData, "(&sm&sb)", &uid, &whitelist, &_logToSystemConsoleEnabled);
+        g_variant_get((GVariant*) userData, "(&sm&sbm&s)", &uid, &whitelist, &_logToSystemConsoleEnabled, &mixedContentWhitelist);
 
         if (_logToSystemConsoleEnabled && Core::SystemInfo::GetEnvironment(string(_T("CLIENT_IDENTIFIER")), _consoleLogPrefix))
           _consoleLogPrefix = _consoleLogPrefix.substr(0, _consoleLogPrefix.find(','));
@@ -121,6 +123,13 @@ public:
             auto list = WebKit::WhiteListedOriginDomainsList::Parse(whitelist);
             if (list) {
               list->AddWhiteListToWebKit(extension);
+            }
+        }
+
+        if (mixedContentWhitelist != nullptr) {
+            auto list = WebKit::MixedContentWhiteListedOriginDomainsList::Parse(mixedContentWhitelist);
+            if (list) {
+              list->AddMixedContentWhitelistToWebKit(extension);
             }
         }
 

--- a/WebKitBrowser/Extension/main.cpp
+++ b/WebKitBrowser/Extension/main.cpp
@@ -31,7 +31,7 @@
 #include "Milestone.h"
 #include "NotifyWPEFramework.h"
 #include "RequestHeaders.h"
-#include "WhiteListedOriginDomainsList.h"
+#include "CORSWhiteListedOriginDomainsList.h"
 #include "MixedContentWhiteListedOriginDomainsList.h"
 
 #ifdef ENABLE_SECURITY_AGENT
@@ -99,10 +99,10 @@ public:
         _logToSystemConsoleEnabled = FALSE;
 
         const char *uid;
-        const char *whitelist;
-        const char *mixedContentWhitelist;
+        const char *CORSWhitelistJSON;
+        const char *mixedContentJSON;
 
-        g_variant_get((GVariant*) userData, "(&sm&sbm&s)", &uid, &whitelist, &_logToSystemConsoleEnabled, &mixedContentWhitelist);
+        g_variant_get((GVariant*) userData, "(&sm&sbm&s)", &uid, &CORSWhitelistJSON, &_logToSystemConsoleEnabled, &mixedContentJSON);
 
         if (_logToSystemConsoleEnabled && Core::SystemInfo::GetEnvironment(string(_T("CLIENT_IDENTIFIER")), _consoleLogPrefix))
           _consoleLogPrefix = _consoleLogPrefix.substr(0, _consoleLogPrefix.find(','));
@@ -119,18 +119,14 @@ public:
           G_CALLBACK(pageCreatedCallback),
           this);
 
-        if (whitelist != nullptr) {
-            auto list = WebKit::WhiteListedOriginDomainsList::Parse(whitelist);
-            if (list) {
-              list->AddWhiteListToWebKit(extension);
-            }
+        if (CORSWhitelistJSON != nullptr) {
+            WebKit::CORSWhiteListedOriginDomainsList whitelist(CORSWhitelistJSON);
+            whitelist.AddToWebKit(extension);
         }
 
-        if (mixedContentWhitelist != nullptr) {
-            auto list = WebKit::MixedContentWhiteListedOriginDomainsList::Parse(mixedContentWhitelist);
-            if (list) {
-              list->AddMixedContentWhitelistToWebKit(extension);
-            }
+        if (mixedContentJSON != nullptr) {
+            WebKit::MixedContentWhiteListedOriginDomainsList whitelist(mixedContentJSON);
+            whitelist.AddToWebKit(extension);
         }
 
 #if defined(UPDATE_TZ_FROM_FILE)

--- a/WebKitBrowser/WebKitBrowser.config
+++ b/WebKitBrowser/WebKitBrowser.config
@@ -120,7 +120,7 @@ map()
     endif()
     kv(watchdogchecktimeoutinseconds 10)
     kv(watchdoghangthresholdtinseconds 60)
-    kv(whitelist "[{\"origin\":\"https://www.live.bbctvapps.co.uk/\", \"domain\":[\"ws://localhost\", \"ws://127.0.0.1\"], \"subdomain\":true}, {\"origin\":\"https://broadcast.live.bbctvapps.co.uk/\", \"domain\":[\"ws://localhost\", \"ws://127.0.0.1\"], \"subdomain\":true}]")
+    kv(mixedcontentwhitelist "[{\"origin\":\"https://*\", \"domain\":[\"ws://127.0.0.1:10415\", \"ws://127.0.0.1:10016\", \"ws://localhost:10415\", \"ws://localhost:10016\"]}]")
 end()
 ans(configuration)
 

--- a/WebKitBrowser/WebKitBrowserPlugin.json
+++ b/WebKitBrowser/WebKitBrowserPlugin.json
@@ -96,6 +96,23 @@
                         },
                         "required": []
                     },
+                    "mixedcontentwhitelist": {
+                        "type": "object",
+                        "properties": {
+                            "origin": {
+                                "description": "Origin domain allowed to access mixed content in domain, * can be used as a wildcard",
+                                "type": "string"
+                            },
+                            "domain": {
+                                "description": "Mixed content domain allowed to access from origin, * can be used as wildcard",
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                        },
+                        "required": []
+                    },
                     "localstorageenabled": {
                         "summary": "Controls the local storage availability",
                         "type": "boolean"                        

--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -523,6 +523,7 @@ static GSourceFuncs _handlerIntervention =
                 , UserAgent()
                 , URL(_T("http://www.google.com"))
                 , Whitelist()
+                , MixedContentWhitelist()
                 , PageGroup(_T("WPEPageGroup"))
                 , CookieStorage()
                 , CloudCookieJarEnabled(false)
@@ -592,6 +593,7 @@ static GSourceFuncs _handlerIntervention =
                 Add(_T("useragent"), &UserAgent);
                 Add(_T("url"), &URL);
                 Add(_T("whitelist"), &Whitelist);
+                Add(_T("mixedcontentwhitelist"), &MixedContentWhitelist);
                 Add(_T("pagegroup"), &PageGroup);
                 Add(_T("cookiestorage"), &CookieStorage);
                 Add(_T("cloudcookiejarenabled"), &CloudCookieJarEnabled);
@@ -668,6 +670,7 @@ static GSourceFuncs _handlerIntervention =
             Core::JSON::String UserAgent;
             Core::JSON::String URL;
             Core::JSON::String Whitelist;
+            Core::JSON::String MixedContentWhitelist;
             Core::JSON::String PageGroup;
             Core::JSON::String CookieStorage;
             Core::JSON::Boolean CloudCookieJarEnabled;
@@ -2786,7 +2789,7 @@ static GSourceFuncs _handlerIntervention =
         {
             webkit_web_context_set_web_extensions_directory(context, browser->_extensionPath.c_str());
             // FIX it
-            GVariant* data = g_variant_new("(smsb)", std::to_string(browser->_guid).c_str(), !browser->_config.Whitelist.Value().empty() ? browser->_config.Whitelist.Value().c_str() : nullptr, browser->_config.LogToSystemConsoleEnabled.Value());
+            GVariant* data = g_variant_new("(smsbms)", std::to_string(browser->_guid).c_str(), !browser->_config.Whitelist.Value().empty() ? browser->_config.Whitelist.Value().c_str() : nullptr, browser->_config.LogToSystemConsoleEnabled.Value(), !browser->_config.MixedContentWhitelist.Value().empty() ? browser->_config.MixedContentWhitelist.Value().c_str() : nullptr);
             webkit_web_context_set_web_extensions_initialization_user_data(context, data);
         }
         static void wpeNotifyWPEFrameworkMessageReceivedCallback(WebKitUserContentManager*, WebKitJavascriptResult* message, WebKitImplementation* browser)

--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -2789,7 +2789,11 @@ static GSourceFuncs _handlerIntervention =
         {
             webkit_web_context_set_web_extensions_directory(context, browser->_extensionPath.c_str());
             // FIX it
-            GVariant* data = g_variant_new("(smsbms)", std::to_string(browser->_guid).c_str(), !browser->_config.Whitelist.Value().empty() ? browser->_config.Whitelist.Value().c_str() : nullptr, browser->_config.LogToSystemConsoleEnabled.Value(), !browser->_config.MixedContentWhitelist.Value().empty() ? browser->_config.MixedContentWhitelist.Value().c_str() : nullptr);
+            GVariant* data = g_variant_new("(smsbms)",
+                                           std::to_string(browser->_guid).c_str(), //s
+                                           !browser->_config.Whitelist.Value().empty() ? browser->_config.Whitelist.Value().c_str() : nullptr, //ms
+                                           browser->_config.LogToSystemConsoleEnabled.Value(), //b
+                                           !browser->_config.MixedContentWhitelist.Value().empty() ? browser->_config.MixedContentWhitelist.Value().c_str() : nullptr); //ms
             webkit_web_context_set_web_extensions_initialization_user_data(context, data);
         }
         static void wpeNotifyWPEFrameworkMessageReceivedCallback(WebKitUserContentManager*, WebKitJavascriptResult* message, WebKitImplementation* browser)


### PR DESCRIPTION
Controlled via mixedcontentwhitelist entry in plugin config, '*' can be used as a wildcard. Passed to webkit via libextension, similiar to how CORS whitelist works.

Removed the CORS whitelist as we don't need it