### PR TITLE
ONEM-30706 OMI upstreaming (backports)

### DIFF
--- a/OCIContainer/OCIContainer.h
+++ b/OCIContainer/OCIContainer.h
@@ -39,7 +39,6 @@ public:
     uint32_t getContainerState(const JsonObject &parameters, JsonObject &response);
     uint32_t getContainerInfo(const JsonObject &parameters, JsonObject &response);
     uint32_t startContainer(const JsonObject &parameters, JsonObject &response);
-    uint32_t startContainerFromCryptedBundle(const JsonObject &parameters, JsonObject &response);
     uint32_t startContainerFromDobbySpec(const JsonObject &parameters, JsonObject &response);
     uint32_t stopContainer(const JsonObject &parameters, JsonObject &response);
     uint32_t pauseContainer(const JsonObject &parameters, JsonObject &response);

--- a/OCIContainer/OCIContainer.json
+++ b/OCIContainer/OCIContainer.json
@@ -404,68 +404,6 @@
                 ]
             }
         },
-        "startContainerFromCryptedBundle":{
-            "summary": "Starts a new container from an existing encrypted OCI bundle",
-            "params": {
-                "type": "object",
-                "properties": {
-                    "containerId": {
-                        "$ref": "#/definitions/containerId"
-                    },
-                    "rootFSPath": {
-                        "summary": "Path to the enrypted OCI bundle containing the rootfs to use to create the container",
-                        "type": "string",
-                        "example": "/containers/rootfs/myBundle"
-                    },
-                    "configFilePath": {
-                        "summary": "Path to the enrypted OCI bundle containing the config file to use to create the container",
-                        "type": "string",
-                        "example": "/containers/var/myBundle"
-                    },
-                    "command": {
-                        "$ref": "#/definitions/command"
-                    },
-                    "westerosSocket":{
-                        "summary": "Path to a Westeros socket to mount inside the container",
-                        "type": "string",
-                        "example": "/usr/mySocket"
-                    },
-                    "envvar": {
-                        "summary": "A list of environment variables to add to the container",
-                        "type": "array",
-                        "items": {
-                            "type": "string",
-                            "example": "FOO=BAR"
-                        }
-                    }
-                },
-                "required": [
-                    "containerId",
-                    "rootFSPath",
-                    "configFilePath"
-                ]
-            },
-            "result": {
-                "type": "object",
-                "properties": {
-                    "descriptor": {
-                        "$ref": "#/definitions/Descriptor"
-                    },
-                    "success":{
-                        "$ref": "#/common/success"
-                    },
-                    "error":{
-                        "summary": "An error message in case of a failure",
-                        "type": "string",
-                        "example": "internal dobby error"
-                    }
-                },
-                "required": [
-                    "descriptor",
-                    "success"
-                ]
-            }
-        },
         "startContainerFromDobbySpec":{
             "summary": "Starts a new container from a legacy Dobby JSON specification.",
             "events": {

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -127,6 +127,7 @@ target_include_directories(${PROJECT_NAME}
         mocks
         mocks/devicesettings
         mocks/thunder
+        ${CMAKE_CURRENT_SOURCE_DIR}/../OCIContainer/stubs
         )
 
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)


### PR DESCRIPTION
- Backports upstreamed version of startContainer()[1] which can start both plain and dm-verity encrypted applications transparently.

- Removes startContainerFromCryptedBundle() LGi proprietary method.

[1] https://github.com/rdkcentral/rdkservices/pull/4185

no_jenkins