### PR TITLE
[ONEM-31936] Adjust certificates default paths

### DIFF
--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -2078,11 +2078,11 @@ static GSourceFuncs _handlerIntervention =
 
             /* TODO: This configuration is temporary. It'll be moved to plugin config file when architecture will be defined. */
             std::string wpeClientCertsConf {
-                "https://ipsecure.int.bbc.co.uk/=/run/certificates/bbc-iplayer-cert.pem,/run/privatekeys/bbc-iplayer-key.pem\r\n"
-                "https://ipsecure.test.bbc.co.uk/=/run/certificates/bbc-iplayer-cert.pem,/run/privatekeys/bbc-iplayer-key.pem\r\n"
-                "https://ipsecure.stage.bbc.co.uk/=/run/certificates/bbc-iplayer-cert.pem,/run/privatekeys/bbc-iplayer-key.pem\r\n"
-                "https://securegate.iplayer.bbc.co.uk/=/run/certificates/bbc-iplayer-cert.pem,/run/privatekeys/bbc-iplayer-key.pem\r\n"
-                "https://pac.networking.certification.bbctvapps.co.uk/=/run/certificates/bbc-iplayer-cert.pem,/run/privatekeys/bbc-iplayer-key.pem\r\n"};
+                "https://ipsecure.int.bbc.co.uk/=/run/certificates/private/bbc-iplayer-cert.pem,/run/certificates/private/bbc-iplayer-key.pem\r\n"
+                "https://ipsecure.test.bbc.co.uk/=/run/certificates/private/bbc-iplayer-cert.pem,/run/certificates/private/bbc-iplayer-key.pem\r\n"
+                "https://ipsecure.stage.bbc.co.uk/=/run/certificates/private/bbc-iplayer-cert.pem,/run/certificates/private/bbc-iplayer-key.pem\r\n"
+                "https://securegate.iplayer.bbc.co.uk/=/run/certificates/private/bbc-iplayer-cert.pem,/run/certificates/private/bbc-iplayer-key.pem\r\n"
+                "https://pac.networking.certification.bbctvapps.co.uk/=/run/certificates/private/bbc-iplayer-cert.pem,/run/certificates/private/bbc-iplayer-key.pem\r\n"};
 
             std::string urls;
             constexpr auto kUrlsSep = "|";  // not allowed in URI


### PR DESCRIPTION
... from /run/certificates and /run/privatekeys to /run/certificates/private (for both key and certificate files).

no_jenkins