### PR TITLE
[ONEM-32355] Implement DsMgr lib debug callbacks

### DIFF
--- a/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
@@ -38,6 +38,8 @@
 #include "libIBus.h"
 #include "libIBusDaemon.h"
 #include "dsMgr.h"
+#include "dsregisterlog.h"
+#include "dsclientregisterlog.h"
 
 #define EDID_MAX_HORIZONTAL_SIZE 21
 #define EDID_MAX_VERTICAL_SIZE   22
@@ -65,6 +67,8 @@ public:
             IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_RES_POSTCHANGE, ResolutionChange) );
 
             //TODO: this is probably per process so we either need to be running in our own process or be carefull no other plugin is calling it
+            DS_RegisterForLog(dslogCallback);
+            DSClient_RegisterForLog(dslogCallback);
             device::Manager::Initialize();
             TRACE(Trace::Information, (_T("device::Manager::Initialize success")));
         }
@@ -783,6 +787,29 @@ private:
         return ret;
     }
 
+    static void dslogCallback(int priority,const char *buff)
+    {
+        if(priority == 0)
+        {
+            TRACE_GLOBAL(Trace::Information, (_T("%s"),buff));
+        }
+        else if(priority == 1)
+        {
+            TRACE_GLOBAL(Trace::Warning, (_T("%s"), buff));
+        }
+        else if(priority == 2)
+        {
+            TRACE_GLOBAL(Trace::Error, (_T("%s"), buff));
+        }
+        else if(priority == 3)
+        {
+            TRACE_GLOBAL(Trace::Information, (_T("%s"), buff));
+        }
+        else
+        {
+            TRACE_GLOBAL(Trace::Error, (_T("[%s] invalid priority:0x%x"), __FUNCTION__, priority));
+        }
+    }
 
 public:
     static DisplayInfoImplementation* _instance;

--- a/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
@@ -789,19 +789,19 @@ private:
 
     static void dslogCallback(int priority,const char *buff)
     {
-        if(priority == 0)
+        if(priority == DS_LOG_LEVEL_INFO)
         {
             TRACE_GLOBAL(Trace::Information, (_T("%s"),buff));
         }
-        else if(priority == 1)
+        else if(priority == DS_LOG_LEVEL_WARN)
         {
             TRACE_GLOBAL(Trace::Warning, (_T("%s"), buff));
         }
-        else if(priority == 2)
+        else if(priority == DS_LOG_LEVEL_ERROR)
         {
             TRACE_GLOBAL(Trace::Error, (_T("%s"), buff));
         }
-        else if(priority == 3)
+        else if(priority == DS_LOG_LEVEL_DEBUG)
         {
             TRACE_GLOBAL(Trace::Information, (_T("%s"), buff));
         }


### PR DESCRIPTION
Debug callbacks has been registered for libds and libds-rpc in order to get debugs from these libs through the same debug interface that is used by the process linking them.
Thanks to that temporal order of debugs is preserved and verbosity of debugs can be controlled. If no debug callbacks are registered both libraries are printing all their debug output to stdout.