### PR TITLE
[ONEM-33162]: WPE 2.38 - port debug logs for JS logs not seen in Journal

### DIFF
--- a/WebKitBrowser/Extension/main.cpp
+++ b/WebKitBrowser/Extension/main.cpp
@@ -196,8 +196,7 @@ private:
     {
         string messageString = Core::ToString(webkit_console_message_get_text(message));
         uint64_t line = static_cast<uint64_t>(webkit_console_message_get_line(message));
-
-        TRACE_GLOBAL(BrowserConsoleLog, (host->_consoleLogPrefix, messageString, line, 0));
+	TRACE_GLOBAL(Trace::Warning, (_T("consoleMessageSentCallback-> %llu messageString: %s"), line, messageString.c_str()));
     }
     static gboolean userMessageReceivedCallback(WebKitWebPage* page, WebKitUserMessage* message)
     {

--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -3045,7 +3045,7 @@ static GSourceFuncs _handlerIntervention =
         static void initializeWebExtensionsCallback(WebKitWebContext* context, WebKitImplementation* browser)
         {
             webkit_web_context_set_web_extensions_directory(context, browser->_extensionPath.c_str());
-            // FIX it
+	    // FIX it
             GVariant* data = g_variant_new("(smsbms)",
                                            std::to_string(browser->_guid).c_str(), //s
                                            !browser->_config.Whitelist.Value().empty() ? browser->_config.Whitelist.Value().c_str() : nullptr, //ms


### PR DESCRIPTION
WPE 2.38 - port debug logs for JS logs not seen in Journal

JS logs are not printed in journal for below use case.

case1:
 open CNN app
- in the web inspector console execute this script: 
var xhr = new XMLHttpRequest(); xhr.open('GET', 'https://example.com', true); xhr.send();
- in the journalctl you should see " XMLHttpRequest cannot load https://example.com "
case2:
(function () {
  if (typeof navigator.requestMediaKeySystemAccess === "function") {
    const keySystems = ["org.w3.clearkey"];

    keySystems.forEach(async (keySystem) => {
      try {
        const keySystemConfig = {
          initDataTypes: ["cenc"],
          videoCapabilities: [
            { contentType: 'video/mp4; codecs="avc1.42E01E"' },
          ],
        };

        const keySystemAccess = await navigator.requestMediaKeySystemAccess(
          keySystem,
          [keySystemConfig]
        );
        console.log(keySystem, "is supported.");
      } catch (error) {
        console.log(keySystem, "is NOT supported.");
      }
    });
  } else {
    console.log("EME API is not supported in this browser.");
  }
})();

case3:
console.log("something should be in journal logs"); from web inspector.