### PR TITLE
ARRISEOS-45463: [SCA] Potential bugs found during SCA in displaysettings

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -2328,7 +2328,6 @@ namespace WPEFramework {
                  device::Host::getInstance().getCurrentAudioFormat(audioFormat);
                  LOGINFO("current audio format: %d \n", audioFormat);
                  audioFormatToString(audioFormat, response);
-                 success = true;
              }
              catch (const device::Exception& err)
              {
@@ -2910,7 +2909,6 @@ namespace WPEFramework {
                 {
                         device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
                         aPort.setGain(newGain);
-                        success= true;
                 }
                 catch (const device::Exception& err)
                 {
@@ -2968,7 +2966,6 @@ namespace WPEFramework {
                 {
                         device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
                         aPort.setLevel(level);
-                        success= true;
                 }
                 catch (const device::Exception& err)
                 {


### PR DESCRIPTION
3 * [CWE-1164] V1048: The 'success' variable was assigned the same value.

Issues reference: https://sonarqube.onemw.net/project/issues?id=rdkservice-displaysettings-rdk14&resolved=false
Testing change: https://gerrit.onemw.net/c/meta-lgi-om-common/+/115262
Verification SCA build: https://jenkins.onemw.net/job/StaticCodeAnalysis/job/Analyze-with-PVSStudio/380/