### PR TITLE
ARRISEOS-45465: [SCA] Potential bugs found during SCA in rdkservices-rdk14

### DIFF
--- a/TraceControl/TraceControlJsonRpc.cpp
+++ b/TraceControl/TraceControlJsonRpc.cpp
@@ -52,7 +52,6 @@ namespace Plugin {
             newState = JsonData::TraceControl::StateType::ENABLED;
             break;
         case TraceControl::state::DISABLED:
-            newState = JsonData::TraceControl::StateType::DISABLED;
             break;
         case TraceControl::state::TRISTATED:
             newState = JsonData::TraceControl::StateType::TRISTATED;


### PR DESCRIPTION
Issue reference: https://sonarqube.onemw.net/project/issues?id=rdkservices-rdk14&resolved=false
BUG: [CWE-1164] V1048: The 'newState' variable was assigned the same value. (line 55)
Testing change: https://gerrit.onemw.net/c/meta-lgi-om-common/+/115265/1/
Test SCA build: https://jenkins.onemw.net/job/StaticCodeAnalysis/job/Analyze-with-PVSStudio/383/