### PR TITLE
ONEM-30801: WPE 2.38 - WPE goes to SUSPENDED with about:blank loaded …

### DIFF
--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -2303,7 +2303,7 @@ static GSourceFuncs _handlerIntervention =
             const bool isNewUrlBlankUrl = URL.find("about:blank") != string::npos;
             static const auto metroDomain = _bootUrl.substr(0, _bootUrl.find('#'));
             const bool isNewUrlMetroSubdomain = URL.find(metroDomain) != string::npos;
-            if (isNewUrlBlankUrl || isNewUrlMetroSubdomain || isNewUrlBootUrl) {
+            if (isNewUrlBlankUrl || (isNewUrlMetroSubdomain && !isNewUrlBootUrl)) {
                 /*
                  * When loading URL from the same domain only notify::uri signal is being sent.
                  * This scenario happens only for Metro domain addresses.


### PR DESCRIPTION
WPE 2.38 - WPE goes to SUSPENDED with about:blank loaded after kill -9

If current URL is in metro subdomain (app or boot) and if new URL is also metro subdomain or if the new URL is about:blank then we should not wait for load result and we must send the notification to the AWC using  notifyUrlLoadResult(URL, Core::ERROR_NONE).