### PR TITLE
ARRISEOS-46010: propagate all load failed events

### DIFF
--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -3379,7 +3379,6 @@ static GSourceFuncs _handlerIntervention =
             SYSLOG_GLOBAL(Logging::Notification, (_T("LoadFailed: %s"), message.c_str()));
             if (g_error_matches(error, WEBKIT_NETWORK_ERROR, WEBKIT_NETWORK_ERROR_CANCELLED)) {
                 browser->_ignoreLoadFinishedOnce = true;
-                return;
             }
             browser->OnLoadFailed(failingURI);
         }


### PR DESCRIPTION
In the ticket logs we have load failed for boot URL that causes 15 seconds waiting for setup URL request remove only return
Test results: https://jira.lgi.io/browse/ARRISEOS-46010?focusedCommentId=5480605