### PR TITLE
ONEM-36392: Remove whitelisting of Vevo app.

### DIFF
--- a/WebKitBrowser/WebKitBrowser.config
+++ b/WebKitBrowser/WebKitBrowser.config
@@ -124,7 +124,7 @@ map()
     kv(watchdogchecktimeoutinseconds 10)
     kv(watchdoghangthresholdtinseconds 60)
     kv(webaudio true)
-    kv(mixedcontentwhitelist "[{\"origin\":\"https://*\", \"domain\":[\"ws://127.0.0.1:10415\", \"ws://127.0.0.1:10016\", \"ws://localhost:10415\", \"ws://localhost:10016\", \"http://127.0.0.1:83\", \"http://127.0.0.1:10414\", \"http://localhost:83\", \"http://localhost:10414\"]}, {\"origin\":\"https://*.channel5.com*\", \"domain\":[\"http://*\"]}, {\"origin\":\"https://cdn.metrological.com*\", \"domain\":[\"http://adm.fwmrm.net*\", \"http://*.vevo.com*\"]}, {\"origin\":\"https://widgets.metrological.com*\", \"domain\":[\"http://tv.metrological.api.radioline.fr*\"]}]")
+    kv(mixedcontentwhitelist "[{\"origin\":\"https://*\", \"domain\":[\"ws://127.0.0.1:10415\", \"ws://127.0.0.1:10016\", \"ws://localhost:10415\", \"ws://localhost:10016\", \"http://127.0.0.1:83\", \"http://127.0.0.1:10414\", \"http://localhost:83\", \"http://localhost:10414\"]}, {\"origin\":\"https://*.channel5.com*\", \"domain\":[\"http://*\"]}, {\"origin\":\"https://widgets.metrological.com*\", \"domain\":[\"http://tv.metrological.api.radioline.fr*\"]}]")
 end()
 ans(configuration)
 


### PR DESCRIPTION
Remove whitelisting of Vevo app since it is currently does not support mixed content.