### PR TITLE
ONEM-33246: Expose Host ICE candidates

### DIFF
--- a/WebKitBrowser/WebKitBrowser.config
+++ b/WebKitBrowser/WebKitBrowser.config
@@ -125,6 +125,7 @@ map()
     kv(watchdoghangthresholdtinseconds 60)
     kv(webaudio true)
     kv(mixedcontentwhitelist "[{\"origin\":\"https://*\", \"domain\":[\"ws://127.0.0.1:10415\", \"ws://127.0.0.1:10016\", \"ws://localhost:10415\", \"ws://localhost:10016\", \"http://127.0.0.1:83\", \"http://127.0.0.1:10414\", \"http://localhost:83\", \"http://localhost:10414\"]}, {\"origin\":\"https://*.channel5.com*\", \"domain\":[\"http://*\"]}, {\"origin\":\"https://cdn.metrological.com*\", \"domain\":[\"http://adm.fwmrm.net*\", \"http://*.vevo.com*\"]}, {\"origin\":\"https://widgets.metrological.com*\", \"domain\":[\"http://tv.metrological.api.radioline.fr*\"]}]")
+    kv(icecandidatefiltering false)
 end()
 ans(configuration)
 


### PR DESCRIPTION
By default, without access to capture devices, WebKit only exposes Server Reflexive and TURN ICE candidates. When access to capture devices is granted, WebKit will expose host ICE candidates.

LGI scenarios require usage of Host ICE candidates without capture device and within the same local network.