### PR TITLE
[ONEM-36849]:clang compilaion an issue fixed

### DIFF
--- a/WebKitBrowser/BrowserConsoleLog.h
+++ b/WebKitBrowser/BrowserConsoleLog.h
@@ -20,7 +20,10 @@
 #ifndef __BROWSERCONSOLELOG_H
 #define __BROWSERCONSOLELOG_H
 
+#ifndef __CORE_MESSAGING__
+#define __CORE_MESSAGING__
 #include <tracing/tracing.h>
+#endif
 #ifndef WEBKIT_GLIB_API
 #include "InjectedBundle/Utils.h"
 #endif

--- a/WebKitBrowser/Extension/Module.h
+++ b/WebKitBrowser/Extension/Module.h
@@ -25,7 +25,9 @@
 
 #include <com/com.h>
 #include <core/core.h>
+#ifndef __CORE_MESSAGING__
+#define __CORE_MESSAGING__
 #include <tracing/tracing.h>
-
+#endif
 #undef EXTERNAL
 #define EXTERNAL

--- a/WebKitBrowser/Extension/main.cpp
+++ b/WebKitBrowser/Extension/main.cpp
@@ -89,7 +89,7 @@ public:
         // We have something to report back, do so...
         uint32_t result = _comClient->Open(RPC::CommunicationTimeOut);
         if (result != Core::ERROR_NONE) {
-            TRACE(Trace::Error, (_T("Could not open connection to node %s. Error: %s"), _comClient->Source().RemoteId(), Core::NumberType<uint32_t>(result).Text()));
+            TRACE(Trace::Error, (_T("Could not open connection to node %s. Error: %s"), _comClient->Source().RemoteId().c_str(), Core::NumberType<uint32_t>(result).Text().c_str()));
         } else {
             // Due to the LXC container support all ID's get mapped. For the TraceBuffer, use the host given ID.
             Messaging::MessageUnit::Instance().Open(_comClient->ConnectionId());

--- a/WebKitBrowser/HTML5Notification.h
+++ b/WebKitBrowser/HTML5Notification.h
@@ -20,7 +20,10 @@
 #ifndef __HTML5NOTIFICATION_H
 #define __HTML5NOTIFICATION_H
 
+#ifndef __CORE_MESSAGING__
+#define __CORE_MESSAGING__
 #include <tracing/tracing.h>
+#endif
 
 using namespace WPEFramework;
 


### PR DESCRIPTION
WPE2.38 and Thunder fails on clang compilation:
Error:
TOPDIR/tmp/work/cortexa15t2hf-neon-vfpv4-rdk-linux-gnueabi/webkitbrowser-plugin/3.0+gitAUTOINC+302aa36687-r1/recipe-sysroot/usr/include/WPEFramework/messaging/Logging.h:25:\nTOPDIR/tmp/work/cortexa15t2hf-neon-vfpv4-rdk-linux-gnueabi/webkitbrowser-plugin/3.0+gitAUTOINC+302aa36687-r1/recipe-sysroot/usr/include/WPEFramework/messaging/BaseCategory.h:37:52: error: cannot pass object of non-trivial type 'std::__cxx11::basic_string<char>' through variadic function; call will abort at runtime [-Wnon-pod-varargs]\n            Core::Format(_text, formatter.c_str(), args...);\n                                                   ^\nTOPDIR/tmp/work/cortexa15t2hf-neon-vfpv4-rdk-linux-gnueabi/webkitbrowser-plugin/3.0+gitAUTOINC+302aa36687-r1/git/WebKitBrowser/Extension/main.cpp:92:13: note: in instantiation of function template specialization 'WPEFramework::Messaging::BaseCategoryType<WPEFramework::Core::Messaging::Metadata::TRACING>::BaseCategoryType<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>>' requested here\n            TRACE(Trace::Error, (_T(\"Could not open connection to node %s. Error: %s\"), _comClient->Source().RemoteId(), Core::NumberType<uint32_t>(result).Text()));\n            ^\nTOPDIR/tmp/work/cortexa15t2hf-neon-vfpv4-rdk-linux-gnueabi/webkitbrowser-plugin/3.0+gitAUTOINC+302aa36687-r1/recipe-sysroot/usr/include/WPEFramework/messaging/TraceControl.h:47:22: note: expanded from macro 'TRACE'\n            CATEGORY __data__ PARAMETERS;                                                    \\\n                     ^\nIn file included from TOPDIR/tmp/work/cortexa15t2hf-neon-vfpv4-rdk-linux-gnueabi/webkitbrowser-plugin/3.0+gitAUTOINC+302aa36687-r1/git/WebKitBrowser/Extension/main.cpp:20:\nIn file included from 