### PR TITLE
ARRISEOS-46312: Whitelist webRTC test page

### DIFF
--- a/WebKitBrowser/WebKitBrowser.config
+++ b/WebKitBrowser/WebKitBrowser.config
@@ -124,7 +124,7 @@ map()
     kv(watchdogchecktimeoutinseconds 10)
     kv(watchdoghangthresholdtinseconds 60)
     kv(webaudio true)
-    kv(mixedcontentwhitelist "[{\"origin\":\"https://*\", \"domain\":[\"ws://127.0.0.1:10415\", \"ws://127.0.0.1:10016\", \"ws://localhost:10415\", \"ws://localhost:10016\", \"http://127.0.0.1:83\", \"http://127.0.0.1:10414\", \"http://localhost:83\", \"http://localhost:10414\"]}, {\"origin\":\"https://widgets.metrological.com*\", \"domain\":[\"http://tv.metrological.api.radioline.fr*\"]}]")
+    kv(mixedcontentwhitelist "[{\"origin\":\"https://*\", \"domain\":[\"ws://127.0.0.1:10415\", \"ws://127.0.0.1:10016\", \"ws://localhost:10415\", \"ws://localhost:10016\", \"http://127.0.0.1:83\", \"http://127.0.0.1:10414\", \"http://localhost:83\", \"http://localhost:10414\"]}, {\"origin\":\"https://widgets.metrological.com*\", \"domain\":[\"http://tv.metrological.api.radioline.fr*\"]}, {\"origin\":\"https://wpt.live*\", \"domain\":[\"http://www1.wpt.live*\"]}]")
 end()
 ans(configuration)
 


### PR DESCRIPTION
To pass some webRTC conformance testing, HTTP address needs to be whitelisted.
We're not going to merge this change, it's just for the reference what's needed to pass some of the webRTC tests.