### PR TITLE
ONEM-36378 OnBindLicense

### DIFF
--- a/OpenCDMi/FrameworkRPC.cpp
+++ b/OpenCDMi/FrameworkRPC.cpp
@@ -512,6 +512,11 @@ namespace Plugin {
                         _callback->OnKeyStatusesUpdated();
                     }
 
+                    void OnBindLicense(uint32_t callbackType, const uint8_t *licenseMessage, const uint8_t licenseMessageLength) override
+                    {
+                        _callback->OnBindLicense(callbackType, licenseMessage, licenseMessageLength);
+                    }
+
                 private:
                     SessionImplementation& _parent;
                     Exchange::ISession::ICallback* _callback;


### PR DESCRIPTION
Adding missing callback after IDRM/IOCDM interfaces update. Change depends on:
https://gerrit.onemw.net/#/c/meta-thunder-rdkservices/+/120329/