### PR TITLE
ARRISEOS-46537 SonarQube: rdkservice-xcast (lgi-thunder4.2-20230922)

### DIFF
--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -596,14 +596,7 @@ void XCast::updateDynamicAppCache(JsonArray applications)
                 for (int i = 0; i < jNames.Length(); i++) {
                     itrName = jNames[i].String().c_str();
                     LOGINFO("%s, size:%d", itrName.c_str(), (int)strlen (itrName.c_str()));
-                    DynamicAppConfig* pDynamicAppConfig = (DynamicAppConfig*) malloc (sizeof(DynamicAppConfig));
-                    memset ((void*)pDynamicAppConfig, '0', sizeof(DynamicAppConfig));
-                    memset (pDynamicAppConfig->appName, '\0', sizeof(pDynamicAppConfig->appName));
-                    strcpy (pDynamicAppConfig->appName, itrName.c_str());
-                    memset (pDynamicAppConfig->prefixes, '\0', sizeof(pDynamicAppConfig->prefixes));
-                    memset (pDynamicAppConfig->cors, '\0', sizeof(pDynamicAppConfig->cors));
-                    memset (pDynamicAppConfig->query, '\0', sizeof(pDynamicAppConfig->query));
-                    memset (pDynamicAppConfig->payload, '\0', sizeof(pDynamicAppConfig->payload));
+                    DynamicAppConfig *pDynamicAppConfig = new DynamicAppConfig(itrName.c_str());
                     appConfigListTemp.push_back (pDynamicAppConfig);
                 }
             }


### PR DESCRIPTION
Correcting issues found by SonarQube:
1. The 'malloc' function is used to allocate memory for an array of
objects which are classes containing
constructors.
DynamicAppConfig* pDynamicAppConfig = (DynamicAppConfig*) malloc (sizeof(DynamicAppConfig));

2. The potential null pointer is passed into 'memset' function. Inspect the
first argument.
memset ((void*)pDynamicAppConfig, '0', sizeof(DynamicAppConfig));

The above two issues were corrected by
initializing pDynamicAppConfig in the
intended way and by making use of the
constructor which already does all the
memset operations that were done in
this scope.