### PR TITLE
[ARRISAPP-1197]-Crash in LgiNetwork RDK service (null pointer access)

### DIFF
--- a/LgiNetwork/dbus/lginetwork_client.cpp
+++ b/LgiNetwork/dbus/lginetwork_client.cpp
@@ -476,8 +476,7 @@ void LgiNetworkClient::Stop()
     if (m_interface)
     {
         disconnectAllSignals();
-        release_networkconfig1(m_interface);
-        m_interface = nullptr;
+     
         g_main_context_invoke(m_mainContext, +[](gpointer ptr) -> gboolean {
             LOGINFO("LgiNetworkClient::Stop() quit main loop TID: %u", gettid());
             g_main_loop_quit((GMainLoop*)ptr);
@@ -490,6 +489,8 @@ void LgiNetworkClient::Stop()
         else {
             LOGERR("Worker thread should be joinable");
         }
+	release_networkconfig1(m_interface);
+	m_interface = nullptr;
         LOGINFO("signals disconnected");
     }
 }


### PR DESCRIPTION
Most probably happen when service is stopping and network status changed in meantime. Due to bad logic in LgiNetworkClient::Stop() implementation, event handlers are still active while m_interface is already destroyed (set to NULL). Thus leads to NULL pointer access from handler context.

Replication path/steps:
Possible scenario: STB restart

Actual results:
Crash of WPEFramework process

Expected results:
WPEFramework process should exit with no error