### PR TITLE
ARRISAPP-1229: WPEFramework crashed in browser deactivation

### DIFF
--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -3583,6 +3583,15 @@ static GSourceFuncs _handlerIntervention =
             }
             browser->OnLoadFailed(failingURI);
         }
+        static void postExitJob()
+        {
+            struct ExitJob : public Core::IDispatch
+            {
+                virtual void Dispatch() { exit(1); }
+            };
+
+            Core::IWorkerPool::Instance().Submit(Core::ProxyType<Core::IDispatch>(Core::ProxyType<ExitJob>::Create()));
+        }
         static void webProcessTerminatedCallback(VARIABLE_IS_NOT_USED WebKitWebView* webView, WebKitWebProcessTerminationReason reason, WebKitImplementation* browser)
         {
             switch (reason) {
@@ -3597,11 +3606,7 @@ static GSourceFuncs _handlerIntervention =
                 break;
             }
             g_signal_handlers_block_matched(webView, G_SIGNAL_MATCH_DATA, 0, 0, nullptr, nullptr, browser);
-            struct ExitJob : public Core::IDispatch
-            {
-                virtual void Dispatch() { exit(1); }
-            };
-            Core::IWorkerPool::Instance().Submit(Core::ProxyType<Core::IDispatch>(Core::ProxyType<ExitJob>::Create()));
+            postExitJob();
         }
         static void closeCallback(VARIABLE_IS_NOT_USED WebKitWebView* webView, WebKitImplementation* browser)
         {
@@ -4408,7 +4413,9 @@ static GSourceFuncs _handlerIntervention =
 
         void DeactivateBrowser(PluginHost::IShell::reason reason) {
             ASSERT(_service != nullptr);
-            Core::IWorkerPool::Instance().Submit(PluginHost::IShell::Job::Create(_service, PluginHost::IShell::DEACTIVATED, reason));
+            const char *reasonStr = Core::EnumerateType<PluginHost::IShell::reason>(reason).Data();
+            SYSLOG(Logging::Fatal, (_T("Posting a job to exit, reason - %s"), (reasonStr ? reasonStr : "")));
+            postExitJob();
         }
 
     private:


### PR DESCRIPTION
Crashes reported with WPEFramework::Plugin::WebKitImplementation::DeactivateBrowser() in callstack.
This fix is to avoid crash on exit due use of invalid IShell handle with posting a job to exit() instead of dispatching Deactivated on IShell.

Changes taken from upstream: https://github.com/rdkcentral/rdkservices/commit/d73cf6b04ff4d189e42bd2238a58cd58db08c6c2

Actual results:
crash reported

Expected results:
no crashes observed