### PR TITLE
ARRISEOS-46982: [SCA] Potential bugs found during static code analysi…

### DIFF
--- a/WebKitBrowser/WebKitBrowser.cpp
+++ b/WebKitBrowser/WebKitBrowser.cpp
@@ -240,7 +240,7 @@ namespace Plugin {
 
         Core::ProxyType<Web::Response> result(PluginHost::IFactories::Instance().Response());
         Core::TextSegmentIterator index(
-            Core::TextFragment(request.Path, _skipURL, request.Path.length() - _skipURL), false, '/');
+            Core::TextFragment(request.Path, static_cast<uint32_t>(_skipURL), static_cast<uint32_t>(request.Path.length() - _skipURL)), false, '/');
 
         result->ErrorCode = Web::STATUS_BAD_REQUEST;
         result->Message = "Unknown error";

--- a/WebKitBrowser/WebKitBrowser.h
+++ b/WebKitBrowser/WebKitBrowser.h
@@ -293,7 +293,7 @@ namespace Plugin {
         void event_statechange(const bool& suspended); // StateControl
 
     private:
-        uint8_t _skipURL;
+        size_t _skipURL;
         uint32_t _connectionId;
         PluginHost::IShell* _service;
         Exchange::IWebBrowser* _browser;

--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -3653,7 +3653,7 @@ static GSourceFuncs _handlerIntervention =
         {
             struct ExitJob : public Core::IDispatch
             {
-                virtual void Dispatch() { exit(1); }
+                void Dispatch() override { exit(1); }
             };
 
             Core::IWorkerPool::Instance().Submit(Core::ProxyType<Core::IDispatch>(Core::ProxyType<ExitJob>::Create()));


### PR DESCRIPTION
…s in webkitbrowser-plugin

Correcting issues found by SonarQube:
1. CWE-670 - virtual function was overridden incorrectly
2. CWE-197 - Numeric Truncation Error

Above two issues were corrected by replacing the 8-bit variable with type size_t to avoid potential truncation errors and by using the override keyword which will help to avoid signature mismatch.

Upstream PR: 
https://github.com/rdkcentral/rdkservices/pull/6136
https://github.com/rdkcentral/rdkservices/pull/6137