### PR TITLE
ARRISEOS-48304 Stop and flush WorkerPool at deinitialization start

### DIFF
--- a/OpenCDMi/FrameworkRPC.cpp
+++ b/OpenCDMi/FrameworkRPC.cpp
@@ -1611,7 +1611,7 @@ namespace Plugin {
         void Deinitialize(PluginHost::IShell* service) override {
             _thread.Stop();
 
-            TRACE_L1("IWorkerPool stop");
+            TRACE(Trace::Information, ("Stopping worker pool"));
             Core::IWorkerPool::Instance().Stop(true);
 
             std::map<const string, SystemFactory>::iterator factory(_systemToFactory.begin());

--- a/OpenCDMi/FrameworkRPC.cpp
+++ b/OpenCDMi/FrameworkRPC.cpp
@@ -1611,6 +1611,9 @@ namespace Plugin {
         void Deinitialize(PluginHost::IShell* service) override {
             _thread.Stop();
 
+            TRACE_L1("IWorkerPool stop");
+            Core::IWorkerPool::Instance().Stop(true);
+
             std::map<const string, SystemFactory>::iterator factory(_systemToFactory.begin());
 
             std::list<CDMi::ISystemFactory*> deinitialized;


### PR DESCRIPTION
This is to avoid late message execution after some of the resources are already freed.