### PR TITLE
[ARRISEOS-48809] check value of returned webview() URL pointer

### DIFF
--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -4533,7 +4533,7 @@ static GSourceFuncs _handlerIntervention =
                 return;
 
 #ifdef WEBKIT_GLIB_API
-            std::string activeURL(webkit_web_view_get_uri(_view));
+            std::string activeURL(webkit_web_view_get_uri(_view)?:_T("<undefined>"));
             if (_webprocessPID == -1) {
               _webprocessPID = webkit_web_view_get_web_process_identifier(_view);
             }


### PR DESCRIPTION
 - webkit_web_view_get_uri() may return nullptr, s so returned value should be checked before use